### PR TITLE
chore: make SqliteMessageHandle methods public

### DIFF
--- a/sqlite/lib.rs
+++ b/sqlite/lib.rs
@@ -373,7 +373,7 @@ pub struct SqliteMessageHandle {
 }
 
 impl SqliteMessageHandle {
-  async fn finish(&self, success: bool) -> Result<(), SqliteBackendError> {
+  pub async fn finish(&self, success: bool) -> Result<(), SqliteBackendError> {
     let (sender, receiver) = oneshot::channel();
     self
       .request_tx
@@ -389,7 +389,7 @@ impl SqliteMessageHandle {
       .map_err(|_| SqliteBackendError::DatabaseClosed)?
   }
 
-  async fn take_payload(&mut self) -> Result<Vec<u8>, SqliteBackendError> {
+  pub async fn take_payload(&mut self) -> Result<Vec<u8>, SqliteBackendError> {
     Ok(self.payload.take().expect("can't take payload twice"))
   }
 }


### PR DESCRIPTION
We need these methods for the NPM module. `QueueMessageHandle` interface has `#[async_trait::async_trait(?Send)]`, so it can't be used with multithreaded tokio runtime.