### PR TITLE
feat: append versionstamp to key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,7 @@ dependencies = [
  "chrono",
  "denokv_proto",
  "futures",
+ "hex",
  "log",
  "num-bigint",
  "rand",

--- a/proto/convert.rs
+++ b/proto/convert.rs
@@ -148,6 +148,11 @@ impl TryFrom<pb::AtomicWrite> for AtomicWrite {
             .ok_or(ConvertError::DecodeError)?;
           MutationKind::Max(value)
         }
+        (pb::MutationType::MSetSuffixVersionstampedKey, Some(value)) => {
+          let value = decode_value(value.data, value.encoding as i64)
+            .ok_or(ConvertError::DecodeError)?;
+          MutationKind::SetSuffixVersionstampedKey(value)
+        }
         _ => return Err(ConvertError::InvalidMutationKind),
       };
       let expire_at = match mutation.expire_at_ms {

--- a/proto/interface.rs
+++ b/proto/interface.rs
@@ -323,6 +323,7 @@ pub enum MutationKind {
   Sum(KvValue),
   Min(KvValue),
   Max(KvValue),
+  SetSuffixVersionstampedKey(KvValue),
 }
 
 impl MutationKind {
@@ -332,6 +333,7 @@ impl MutationKind {
       MutationKind::Sum(value) => Some(value),
       MutationKind::Min(value) => Some(value),
       MutationKind::Max(value) => Some(value),
+      MutationKind::SetSuffixVersionstampedKey(value) => Some(value),
       MutationKind::Delete => None,
     }
   }

--- a/proto/schema/datapath.proto
+++ b/proto/schema/datapath.proto
@@ -135,6 +135,8 @@ enum MutationType {
   M_MAX = 4;
   // Max the stored value with the new value. Both values must be LE64 encoded.
   M_MIN = 5;
+  // Set the value, with the versionstamp appended to the end of the key as a string.
+  M_SET_SUFFIX_VERSIONSTAMPED_KEY = 9;
 }
 
 // The encoding of a value.

--- a/remote/lib.rs
+++ b/remote/lib.rs
@@ -614,6 +614,14 @@ impl<P: RemotePermissions> Database for Remote<P> {
             expire_at_ms,
           });
         }
+        denokv_proto::MutationKind::SetSuffixVersionstampedKey(value) => {
+          mutations.push(pb::Mutation {
+            key: mutation.key,
+            value: Some(encode_value_to_pb(value)),
+            mutation_type: pb::MutationType::MSetSuffixVersionstampedKey as _,
+            expire_at_ms,
+          });
+        }
       }
     }
 

--- a/sqlite/Cargo.toml
+++ b/sqlite/Cargo.toml
@@ -21,6 +21,7 @@ async-trait.workspace = true
 chrono.workspace = true
 denokv_proto.workspace = true
 futures.workspace = true
+hex.workspace = true
 log.workspace = true
 num-bigint.workspace = true
 rand.workspace = true

--- a/sqlite/backend.rs
+++ b/sqlite/backend.rs
@@ -331,7 +331,7 @@ impl SqliteBackend {
             let mut versionstamp_suffix = [0u8; 22];
             versionstamp_suffix[0] = 0x02;
             hex::encode_to_slice(
-              &new_versionstamp,
+              new_versionstamp,
               &mut versionstamp_suffix[1..21],
             )
             .unwrap();


### PR DESCRIPTION
This adds a new `M_SET_SUFFIX_VERSIONSTAMPED_KEY` mutation type that is same as `M_SET` except that the hex-encoded versionstamp of the current atomic operation is appended to the key.