### PR TITLE
Constrain docker.yml publish to n.n.n tags only

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: docker
 on:
   push:
     branches: ["main"]
-    tags: ["*"]
+    tags: ["[0-9]+.[0-9]+.[0-9]+"]
   pull_request:
     branches: ["main"]
 


### PR DESCRIPTION
Ignore suffix builds like n.n.n-xxxx