### PR TITLE
Bypass npm build for changes in unrelated workflows

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -10,7 +10,7 @@ env:
     tags:
       - '**'
     paths:
-      - '.github/workflows/*.yml'
+      - '.github/workflows/npm.yml'
       - '.github/*.sh'
       - 'npm/src/**'
       - 'npm/napi/**'


### PR DESCRIPTION
No need to run (and wait) on changes to ci/docker ymls only