### PR TITLE
fix: use 'full' feature of tokio_util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,8 +2395,12 @@ checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.2",
  "pin-project-lite",
+ "slab",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tempfile = "3"
 thiserror = "1"
 tokio = { version = "1.33.0", features = ["full"] }
 tokio-stream = "0.1"
-tokio-util = "0.7"
+tokio-util = { version = "0.7", features = ["full"] }
 url = "2"
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
 v8_valueserializer = "0.1.1"


### PR DESCRIPTION
Had to patch this in place to release 0.8.0