### PR TITLE
perf: use chrono:DateTime::from_timestamp

### DIFF
--- a/proto/time.rs
+++ b/proto/time.rs
@@ -10,10 +10,8 @@ pub fn utc_now() -> chrono::DateTime<chrono::Utc> {
   let now = std::time::SystemTime::now()
     .duration_since(std::time::UNIX_EPOCH)
     .expect("system time before Unix epoch");
-  let naive = chrono::NaiveDateTime::from_timestamp_opt(
-    now.as_secs() as i64,
-    now.subsec_nanos(),
-  )
-  .unwrap();
+  let naive =
+    chrono::DateTime::from_timestamp(now.as_secs() as i64, now.subsec_nanos())
+      .unwrap();
   chrono::DateTime::from_naive_utc_and_offset(naive, chrono::Utc)
 }

--- a/remote/time.rs
+++ b/remote/time.rs
@@ -10,10 +10,8 @@ pub fn utc_now() -> chrono::DateTime<chrono::Utc> {
   let now = std::time::SystemTime::now()
     .duration_since(std::time::UNIX_EPOCH)
     .expect("system time before Unix epoch");
-  let naive = chrono::NaiveDateTime::from_timestamp_opt(
-    now.as_secs() as i64,
-    now.subsec_nanos(),
-  )
-  .unwrap();
+  let naive =
+    chrono::DateTime::from_timestamp(now.as_secs() as i64, now.subsec_nanos())
+      .unwrap();
   chrono::DateTime::from_naive_utc_and_offset(naive, chrono::Utc)
 }

--- a/sqlite/time.rs
+++ b/sqlite/time.rs
@@ -10,10 +10,8 @@ pub fn utc_now() -> chrono::DateTime<chrono::Utc> {
   let now = std::time::SystemTime::now()
     .duration_since(std::time::UNIX_EPOCH)
     .expect("system time before Unix epoch");
-  let naive = chrono::NaiveDateTime::from_timestamp_opt(
-    now.as_secs() as i64,
-    now.subsec_nanos(),
-  )
-  .unwrap();
+  let naive =
+    chrono::DateTime::from_timestamp(now.as_secs() as i64, now.subsec_nanos())
+      .unwrap();
   chrono::DateTime::from_naive_utc_and_offset(naive, chrono::Utc)
 }


### PR DESCRIPTION
[from_timestamp_opt](https://docs.rs/chrono/latest/chrono/struct.NaiveDateTime.html#method.from_timestamp_opt) deprecated since 0.4.35: use DateTime::from_timestamp instead.