### PR TITLE
remote: fix metadata refresher lifetime and stale token recovery

### DIFF
--- a/remote/Cargo.toml
+++ b/remote/Cargo.toml
@@ -32,3 +32,4 @@ deno_error.workspace = true
 
 [dev-dependencies]
 reqwest.workspace = true
+tokio = { workspace = true, features = ["test-util"] }

--- a/remote/lib.rs
+++ b/remote/lib.rs
@@ -374,14 +374,19 @@ impl<P: RemotePermissions, T: RemoteTransport> Remote<P, T> {
           // An auth failure usually means the token went stale (the
           // server may apply clock leeway beyond `expires_at`, so the
           // expiry check above does not catch every case). Force a
-          // metadata refresh and retry once before giving up.
-          if matches!(
-            status,
-            StatusCode::BAD_REQUEST
-              | StatusCode::UNAUTHORIZED
-              | StatusCode::FORBIDDEN
-          ) && !refreshed_on_auth_error
-          {
+          // metadata refresh and retry once before giving up. 401/403
+          // are unambiguous; some servers report auth failures as 400
+          // (e.g. `invalidAuthorizationHeader`), so a 400 counts only
+          // when the response body implicates the authorization
+          // header, to avoid replaying genuinely malformed requests.
+          let is_auth_failure = match status {
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => true,
+            StatusCode::BAD_REQUEST => {
+              body.to_lowercase().contains("authorization")
+            }
+            _ => false,
+          };
+          if is_auth_failure && !refreshed_on_auth_error {
             refreshed_on_auth_error = true;
             warn!(
               "KV Connect failed to call '{}' (status={}): {}; refreshing metadata and retrying",
@@ -468,7 +473,10 @@ async fn metadata_refresh_task<T: RemoteTransport>(
   refresh_now: Arc<Notify>,
 ) {
   // Sleep for the given duration, or until a refresh is explicitly
-  // requested via `refresh_now`, whichever comes first.
+  // requested via `refresh_now`, whichever comes first. Note: if a
+  // refresh request lands while a fetch is already in flight,
+  // `notify_one` stores a permit and the next `notified()` returns
+  // immediately, producing one redundant (but harmless) fetch.
   let sleep_or_refresh_now = |duration: Duration| {
     let refresh_now = refresh_now.clone();
     async move {

--- a/remote/lib.rs
+++ b/remote/lib.rs
@@ -46,6 +46,7 @@ use serde::Deserialize;
 use thiserror::Error;
 use time::utc_now;
 use tokio::sync::watch;
+use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio_util::codec::LengthDelimitedCodec;
 use tokio_util::io::StreamReader;
@@ -56,6 +57,9 @@ use denokv_proto::datapath as pb;
 
 const DATAPATH_BACKOFF_BASE: Duration = Duration::from_millis(200);
 const METADATA_BACKOFF_BASE: Duration = Duration::from_secs(5);
+// How long a data path call waits for a forced metadata refresh to
+// complete before proceeding with whatever metadata it has.
+const FORCED_REFRESH_WAIT: Duration = Duration::from_secs(5);
 
 pub struct MetadataEndpoint {
   pub url: Url,
@@ -226,11 +230,25 @@ pub enum CallDataError {
   Decode(#[source] prost::DecodeError),
 }
 
+/// Owns the background metadata refresh task. The task is aborted when
+/// this struct is dropped, which happens only when the last clone of
+/// the owning [`Remote`] is dropped (it is held in an [`Arc`]).
+struct MetadataRefresher {
+  refresh_now: Arc<Notify>,
+  handle: JoinHandle<()>,
+}
+
+impl Drop for MetadataRefresher {
+  fn drop(&mut self) {
+    self.handle.abort();
+  }
+}
+
 #[derive(Clone)]
 pub struct Remote<P: RemotePermissions, T: RemoteTransport> {
   permissions: P,
   client: T,
-  metadata_refresher: Arc<JoinHandle<()>>,
+  metadata_refresher: Arc<MetadataRefresher>,
   metadata: watch::Receiver<MetadataState>,
 }
 
@@ -241,17 +259,35 @@ impl<P: RemotePermissions, T: RemoteTransport> Remote<P, T> {
     metadata_endpoint: MetadataEndpoint,
   ) -> Self {
     let (tx, rx) = watch::channel(MetadataState::Pending);
-    let metadata_refresher = tokio::spawn(metadata_refresh_task(
+    let refresh_now = Arc::new(Notify::new());
+    let handle = tokio::spawn(metadata_refresh_task(
       client.clone(),
       metadata_endpoint,
       tx,
+      refresh_now.clone(),
     ));
     Self {
       client,
       permissions,
-      metadata_refresher: Arc::new(metadata_refresher),
+      metadata_refresher: Arc::new(MetadataRefresher {
+        refresh_now,
+        handle,
+      }),
       metadata: rx,
     }
+  }
+
+  /// Ask the refresh task to fetch fresh metadata immediately and wait
+  /// (bounded by [`FORCED_REFRESH_WAIT`]) for an update to be
+  /// published.
+  async fn force_refresh_metadata(&self) {
+    let mut metadata_rx = self.metadata.clone();
+    // Mark the current value as seen so `changed()` below waits for a
+    // genuinely new publication.
+    metadata_rx.borrow_and_update();
+    self.metadata_refresher.refresh_now.notify_one();
+    let _ =
+      tokio::time::timeout(FORCED_REFRESH_WAIT, metadata_rx.changed()).await;
   }
 
   async fn call_raw<Req: prost::Message>(
@@ -260,17 +296,37 @@ impl<P: RemotePermissions, T: RemoteTransport> Remote<P, T> {
     req: Req,
   ) -> Result<(T::Response, ProtocolVersion), CallRawError> {
     let attempt = 0;
+    let mut refreshed_on_expiry = false;
+    let mut refreshed_on_auth_error = false;
     let req_body = Bytes::from(req.encode_to_vec());
     loop {
       let metadata = loop {
         let mut metadata_rx = self.metadata.clone();
+        let mut expired = false;
         match &*metadata_rx.borrow() {
           MetadataState::Pending => {}
-          MetadataState::Ok(metadata) => break metadata.clone(),
+          MetadataState::Ok(metadata) => {
+            // Don't send a token that is known to have expired (e.g.
+            // because the process was suspended past the refresh
+            // deadline); force a refresh and re-check. If the refresh
+            // doesn't produce fresh metadata in time, proceed with
+            // what we have rather than hanging.
+            if metadata.expires_at <= utc_now() && !refreshed_on_expiry {
+              expired = true;
+            } else {
+              break metadata.clone();
+            }
+          }
           MetadataState::Error(e) => {
             return Err(CallRawError::Other(e.to_string()));
           }
         };
+        if expired {
+          refreshed_on_expiry = true;
+          debug!("KV Connect metadata expired, forcing refresh");
+          self.force_refresh_metadata().await;
+          continue;
+        }
         if metadata_rx.changed().await.is_err() {
           return Err(CallRawError::DatabaseClosed);
         }
@@ -315,6 +371,25 @@ impl<P: RemotePermissions, T: RemoteTransport> Remote<P, T> {
           let status = resp.1;
           let b = resp.2.bytes().await.unwrap_or_default();
           let body = String::from_utf8_lossy(&b);
+          // An auth failure usually means the token went stale (the
+          // server may apply clock leeway beyond `expires_at`, so the
+          // expiry check above does not catch every case). Force a
+          // metadata refresh and retry once before giving up.
+          if matches!(
+            status,
+            StatusCode::BAD_REQUEST
+              | StatusCode::UNAUTHORIZED
+              | StatusCode::FORBIDDEN
+          ) && !refreshed_on_auth_error
+          {
+            refreshed_on_auth_error = true;
+            warn!(
+              "KV Connect failed to call '{}' (status={}): {}; refreshing metadata and retrying",
+              url, status, body
+            );
+            self.force_refresh_metadata().await;
+            continue;
+          }
           return Err(CallRawError::CallFailed {
             url,
             status,
@@ -371,24 +446,39 @@ impl<P: RemotePermissions, T: RemoteTransport> Remote<P, T> {
   }
 }
 
-impl<P: RemotePermissions, T: RemoteTransport> Drop for Remote<P, T> {
-  fn drop(&mut self) {
-    self.metadata_refresher.abort();
-  }
-}
-
-async fn randomized_exponential_backoff(base: Duration, attempt: u64) {
+fn randomized_exponential_backoff_duration(
+  base: Duration,
+  attempt: u64,
+) -> Duration {
   let attempt = attempt.min(12);
   let delay = base.as_millis() as u64 + (2 << attempt);
   let delay = delay + rand::thread_rng().gen_range(0..(delay / 2) + 1);
-  tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+  std::time::Duration::from_millis(delay)
+}
+
+async fn randomized_exponential_backoff(base: Duration, attempt: u64) {
+  tokio::time::sleep(randomized_exponential_backoff_duration(base, attempt))
+    .await;
 }
 
 async fn metadata_refresh_task<T: RemoteTransport>(
   client: T,
   metadata_endpoint: MetadataEndpoint,
   tx: watch::Sender<MetadataState>,
+  refresh_now: Arc<Notify>,
 ) {
+  // Sleep for the given duration, or until a refresh is explicitly
+  // requested via `refresh_now`, whichever comes first.
+  let sleep_or_refresh_now = |duration: Duration| {
+    let refresh_now = refresh_now.clone();
+    async move {
+      tokio::select! {
+        _ = tokio::time::sleep(duration) => {}
+        _ = refresh_now.notified() => {}
+      }
+    }
+  };
+
   let mut attempts = 0;
   loop {
     let res = fetch_metadata(&client, &metadata_endpoint).await;
@@ -410,7 +500,7 @@ async fn metadata_refresh_task<T: RemoteTransport>(
           .unwrap_or_default()
           .min(Duration::from_secs(60));
 
-        tokio::time::sleep(sleep_time).await;
+        sleep_or_refresh_now(sleep_time).await;
       }
       RetryableResult::Retry => {
         attempts += 1;
@@ -418,7 +508,15 @@ async fn metadata_refresh_task<T: RemoteTransport>(
           // The receiver has been dropped, so we can stop now.
           return;
         }
-        randomized_exponential_backoff(METADATA_BACKOFF_BASE, attempts).await;
+        // Wake any task waiting on a forced refresh; the metadata
+        // value is unchanged, but waiters should re-evaluate rather
+        // than block until their timeout.
+        tx.send_modify(|_| {});
+        sleep_or_refresh_now(randomized_exponential_backoff_duration(
+          METADATA_BACKOFF_BASE,
+          attempts,
+        ))
+        .await;
       }
       RetryableResult::Err(err) => {
         attempts += 1;
@@ -426,7 +524,11 @@ async fn metadata_refresh_task<T: RemoteTransport>(
           // The receiver has been dropped, so we can stop now.
           return;
         }
-        randomized_exponential_backoff(METADATA_BACKOFF_BASE, attempts).await;
+        sleep_or_refresh_now(randomized_exponential_backoff_duration(
+          METADATA_BACKOFF_BASE,
+          attempts,
+        ))
+        .await;
       }
     }
   }

--- a/remote/tests/refresh.rs
+++ b/remote/tests/refresh.rs
@@ -49,6 +49,13 @@ struct MockState {
   /// endpoint always issues that token. Bumping this value simulates
   /// outstanding tokens going stale server-side.
   accepted_token: u64,
+  /// `expiresAt` offset applied to issued metadata. Negative values
+  /// issue metadata that is already expired.
+  ttl_secs: i64,
+  /// When set, metadata fetches beyond this count never complete,
+  /// pinning the published metadata at its current value while
+  /// keeping the refresh task alive (mid-fetch).
+  block_metadata_fetches_after: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -78,19 +85,33 @@ impl RemoteTransport for MockTransport {
     headers: HeaderMap,
     _body: Bytes,
   ) -> Result<(Url, StatusCode, Self::Response), JsErrorBox> {
-    let mut state = self.0.lock().unwrap();
     if url.host_str() == Some("metadata.example") {
-      state.metadata_fetches += 1;
-      let body = serde_json::json!({
-        "version": 3,
-        "databaseId": "11111111-2222-3333-4444-555555555555",
-        "endpoints": [{ "url": "http://data.example", "consistency": "strong" }],
-        "token": format!("tok-{}", state.accepted_token),
-        "expiresAt": (utc_now() + chrono::Duration::seconds(3600)).to_rfc3339(),
-      });
+      let body = {
+        let mut state = self.0.lock().unwrap();
+        state.metadata_fetches += 1;
+        if state
+          .block_metadata_fetches_after
+          .is_some_and(|limit| state.metadata_fetches > limit)
+        {
+          None
+        } else {
+          Some(serde_json::json!({
+            "version": 3,
+            "databaseId": "11111111-2222-3333-4444-555555555555",
+            "endpoints": [{ "url": "http://data.example", "consistency": "strong" }],
+            "token": format!("tok-{}", state.accepted_token),
+            "expiresAt": (utc_now() + chrono::Duration::seconds(state.ttl_secs)).to_rfc3339(),
+          }))
+        }
+      };
+      let Some(body) = body else {
+        futures::future::pending::<()>().await;
+        unreachable!();
+      };
       let response = MockResponse(Bytes::from(body.to_string()));
       return Ok((url, StatusCode::OK, response));
     }
+    let state = self.0.lock().unwrap();
 
     // Note: the double slash mirrors real KV Connect behavior; the
     // endpoint URL is normalized to have a trailing slash and the data
@@ -132,10 +153,21 @@ fn setup() -> (
   Remote<DummyPermissions, MockTransport>,
   Arc<Mutex<MockState>>,
 ) {
-  let state = Arc::new(Mutex::new(MockState {
+  setup_with(MockState {
     metadata_fetches: 0,
     accepted_token: 0,
-  }));
+    ttl_secs: 3600,
+    block_metadata_fetches_after: None,
+  })
+}
+
+fn setup_with(
+  state: MockState,
+) -> (
+  Remote<DummyPermissions, MockTransport>,
+  Arc<Mutex<MockState>>,
+) {
+  let state = Arc::new(Mutex::new(state));
   let metadata_endpoint = MetadataEndpoint {
     url: Url::parse("http://metadata.example/").unwrap(),
     access_token: "testtoken".to_string(),
@@ -210,6 +242,32 @@ async fn dropped_watch_stream_keeps_refresher_alive() {
 
   state.lock().unwrap().accepted_token += 1;
   snapshot_read(&remote).await.unwrap();
+  assert_eq!(metadata_fetches(&state), 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn expired_metadata_forces_refresh_with_bounded_wait() {
+  // The server issues metadata that is already expired, and the
+  // refresh task's next fetch never completes (it immediately
+  // re-fetches because the published metadata is expired, and that
+  // second fetch blocks). The data path must detect the expired
+  // metadata, attempt a forced refresh, and after a bounded wait
+  // proceed with the token it has instead of hanging or failing.
+  let (remote, state) = setup_with(MockState {
+    metadata_fetches: 0,
+    accepted_token: 0,
+    ttl_secs: -1,
+    block_metadata_fetches_after: Some(1),
+  });
+
+  let start = tokio::time::Instant::now();
+  snapshot_read(&remote).await.unwrap();
+  // The forced refresh waited out its bounded timeout (5s) because no
+  // fresh metadata arrived, then fell back to the stale token, which
+  // the mock data path still accepts.
+  assert!(start.elapsed() >= Duration::from_secs(4));
+  // First fetch issued the expired metadata; the second is the
+  // blocked in-flight one.
   assert_eq!(metadata_fetches(&state), 2);
 }
 

--- a/remote/tests/refresh.rs
+++ b/remote/tests/refresh.rs
@@ -1,0 +1,229 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+
+//! Tests for the metadata refresh lifecycle: the background refresh
+//! task must survive clones of `Remote` being dropped (e.g. by watch
+//! streams), and the data path must recover from stale tokens by
+//! forcing a refresh instead of surfacing an auth error.
+
+use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use bytes::Bytes;
+use chrono::Utc;
+use deno_error::JsErrorBox;
+use denokv_proto::datapath as pb;
+use denokv_proto::Consistency;
+use denokv_proto::Database;
+use denokv_proto::ReadRange;
+use denokv_proto::ReadRangeOutput;
+use denokv_proto::SnapshotReadOptions;
+use denokv_remote::MetadataEndpoint;
+use denokv_remote::Remote;
+use denokv_remote::RemoteResponse;
+use denokv_remote::RemoteTransport;
+use futures::Stream;
+use http::HeaderMap;
+use http::StatusCode;
+use prost::Message;
+use url::Url;
+
+/// `chrono`'s "clock" feature is disabled in this workspace; this is
+/// the same helper as `remote/time.rs`.
+fn utc_now() -> chrono::DateTime<Utc> {
+  let now = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .expect("system time before Unix epoch");
+  let naive = chrono::NaiveDateTime::from_timestamp_opt(
+    now.as_secs() as i64,
+    now.subsec_nanos(),
+  )
+  .unwrap();
+  chrono::DateTime::from_naive_utc_and_offset(naive, Utc)
+}
+
+struct MockState {
+  metadata_fetches: u64,
+  /// The data path accepts only `tok-{accepted_token}`; the metadata
+  /// endpoint always issues that token. Bumping this value simulates
+  /// outstanding tokens going stale server-side.
+  accepted_token: u64,
+}
+
+#[derive(Clone)]
+struct MockTransport(Arc<Mutex<MockState>>);
+
+struct MockResponse(Bytes);
+
+impl RemoteResponse for MockResponse {
+  async fn bytes(self) -> Result<Bytes, JsErrorBox> {
+    Ok(self.0)
+  }
+  async fn text(self) -> Result<String, JsErrorBox> {
+    Ok(String::from_utf8(self.0.to_vec()).unwrap())
+  }
+  fn stream(
+    self,
+  ) -> impl Stream<Item = Result<Bytes, JsErrorBox>> + Send + Sync {
+    futures::stream::iter([Ok(self.0)])
+  }
+}
+
+impl RemoteTransport for MockTransport {
+  type Response = MockResponse;
+  async fn post(
+    &self,
+    url: Url,
+    headers: HeaderMap,
+    _body: Bytes,
+  ) -> Result<(Url, StatusCode, Self::Response), JsErrorBox> {
+    let mut state = self.0.lock().unwrap();
+    if url.host_str() == Some("metadata.example") {
+      state.metadata_fetches += 1;
+      let body = serde_json::json!({
+        "version": 3,
+        "databaseId": "11111111-2222-3333-4444-555555555555",
+        "endpoints": [{ "url": "http://data.example", "consistency": "strong" }],
+        "token": format!("tok-{}", state.accepted_token),
+        "expiresAt": (utc_now() + chrono::Duration::seconds(3600)).to_rfc3339(),
+      });
+      let response = MockResponse(Bytes::from(body.to_string()));
+      return Ok((url, StatusCode::OK, response));
+    }
+
+    // Note: the double slash mirrors real KV Connect behavior; the
+    // endpoint URL is normalized to have a trailing slash and the data
+    // path call appends "/{method}".
+    assert_eq!(url.as_str(), "http://data.example//snapshot_read");
+    let authorization = headers
+      .get("authorization")
+      .and_then(|v| v.to_str().ok())
+      .unwrap_or_default();
+    if authorization != format!("Bearer tok-{}", state.accepted_token) {
+      let body = Bytes::from_static(
+        br#"{"code":"invalidAuthorizationHeader","message":"Invalid authorization header"}"#,
+      );
+      let response = MockResponse(body);
+      return Ok((url, StatusCode::BAD_REQUEST, response));
+    }
+
+    let output = pb::SnapshotReadOutput {
+      ranges: vec![pb::ReadRangeOutput { values: vec![] }],
+      read_disabled: false,
+      read_is_strongly_consistent: true,
+      status: pb::SnapshotReadStatus::SrSuccess as i32,
+    };
+    let response = MockResponse(Bytes::from(output.encode_to_vec()));
+    Ok((url, StatusCode::OK, response))
+  }
+}
+
+#[derive(Clone)]
+struct DummyPermissions;
+
+impl denokv_remote::RemotePermissions for DummyPermissions {
+  fn check_net_url(&self, _url: &Url) -> Result<(), JsErrorBox> {
+    Ok(())
+  }
+}
+
+fn setup() -> (
+  Remote<DummyPermissions, MockTransport>,
+  Arc<Mutex<MockState>>,
+) {
+  let state = Arc::new(Mutex::new(MockState {
+    metadata_fetches: 0,
+    accepted_token: 0,
+  }));
+  let metadata_endpoint = MetadataEndpoint {
+    url: Url::parse("http://metadata.example/").unwrap(),
+    access_token: "testtoken".to_string(),
+  };
+  let remote = Remote::new(
+    MockTransport(state.clone()),
+    DummyPermissions,
+    metadata_endpoint,
+  );
+  (remote, state)
+}
+
+fn metadata_fetches(state: &Arc<Mutex<MockState>>) -> u64 {
+  state.lock().unwrap().metadata_fetches
+}
+
+async fn snapshot_read(
+  remote: &Remote<DummyPermissions, MockTransport>,
+) -> Result<Vec<ReadRangeOutput>, JsErrorBox> {
+  remote
+    .snapshot_read(
+      vec![ReadRange {
+        start: vec![],
+        end: vec![0xff],
+        limit: NonZeroU32::new(1).unwrap(),
+        reverse: false,
+      }],
+      SnapshotReadOptions {
+        consistency: Consistency::Strong,
+      },
+    )
+    .await
+}
+
+#[tokio::test(start_paused = true)]
+async fn periodic_refresh_continues() {
+  let (remote, state) = setup();
+  snapshot_read(&remote).await.unwrap();
+  assert_eq!(metadata_fetches(&state), 1);
+
+  // The refresh task sleeps at most 60s between fetches.
+  tokio::time::sleep(Duration::from_secs(61)).await;
+  assert!(metadata_fetches(&state) >= 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn dropped_clone_keeps_refresher_alive() {
+  let (remote, state) = setup();
+  snapshot_read(&remote).await.unwrap();
+  assert_eq!(metadata_fetches(&state), 1);
+
+  // Dropping a clone must not abort the shared metadata refresh task.
+  #[allow(clippy::redundant_clone)]
+  drop(remote.clone());
+
+  // Invalidate the token held by the client; only a fresh metadata
+  // fetch can make the next call succeed.
+  state.lock().unwrap().accepted_token += 1;
+  snapshot_read(&remote).await.unwrap();
+  assert_eq!(metadata_fetches(&state), 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn dropped_watch_stream_keeps_refresher_alive() {
+  let (remote, state) = setup();
+  snapshot_read(&remote).await.unwrap();
+  assert_eq!(metadata_fetches(&state), 1);
+
+  // The watch stream captures a clone of `Remote`; dropping it must
+  // not abort the shared metadata refresh task.
+  drop(remote.watch(vec![vec![1]]));
+
+  state.lock().unwrap().accepted_token += 1;
+  snapshot_read(&remote).await.unwrap();
+  assert_eq!(metadata_fetches(&state), 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn auth_error_forces_refresh_and_retry() {
+  let (remote, state) = setup();
+  snapshot_read(&remote).await.unwrap();
+  assert_eq!(metadata_fetches(&state), 1);
+
+  // Simulate server-side token expiry: the held token is no longer
+  // accepted, but the metadata endpoint issues a valid replacement.
+  // The call must transparently refresh and retry instead of
+  // surfacing an auth error.
+  state.lock().unwrap().accepted_token += 1;
+  snapshot_read(&remote).await.unwrap();
+  assert_eq!(metadata_fetches(&state), 2);
+}


### PR DESCRIPTION
Fixes #137.

* `Remote` derives `Clone` and all clones share one metadata refresh
  task via `Arc<JoinHandle>`, but the `Drop` impl aborted that task on
  every clone drop. `watch()` captures a clone in its stream, so
  dropping a watch stream permanently killed the refresher for the
  whole database handle: the data path then reused the last token
  forever and, once it expired, every call failed with an auth error
  until the process restarted. The abort is moved into a
  `MetadataRefresher` guard owned by the `Arc`, so it fires only when
  the last clone is dropped.
* The data path no longer sends tokens that are known to be expired:
  `call_raw` checks `expires_at` before use and forces an immediate
  metadata refresh (bounded wait) first. The refresh task wakes on
  demand via `Notify` instead of only on its timer, and wakes forced-
  refresh waiters even when a fetch attempt fails.
* On an auth-failure response (400/401/403) from the data path, force
  a metadata refresh and retry once before surfacing the error, so a
  token the server considers stale (e.g. due to clock leeway past
  `expiresAt`) heals transparently.

New tests in `remote/tests/refresh.rs` use a mock transport with
controllable token rotation; the clone-drop, watch-drop, and
auth-retry tests fail against the previous implementation.
