### PR TITLE
chore: fix prettier lint errors in napi test file

### DIFF
--- a/npm/napi/__test__/index.spec.ts
+++ b/npm/napi/__test__/index.spec.ts
@@ -5,19 +5,19 @@ import test from 'ava'
 import { open, close, atomicWrite, dequeueNextMessage, finishMessage, snapshotRead } from '../index'
 
 test('native function exports', (t) => {
-  t.is(typeof open, 'function');
-  t.is(typeof close, 'function');
-  t.is(typeof atomicWrite, 'function');
-  t.is(typeof dequeueNextMessage, 'function');
-  t.is(typeof finishMessage, 'function');
-  t.is(typeof snapshotRead, 'function');
+  t.is(typeof open, 'function')
+  t.is(typeof close, 'function')
+  t.is(typeof atomicWrite, 'function')
+  t.is(typeof dequeueNextMessage, 'function')
+  t.is(typeof finishMessage, 'function')
+  t.is(typeof snapshotRead, 'function')
 })
 
 test('memory db open/close', (t) => {
   t.notThrows(() => {
-    const debug = false;
-    const inMemory = undefined;
-    const dbId = open(':memory:', inMemory, debug);
-    close(dbId, debug);
+    const debug = false
+    const inMemory = undefined
+    const dbId = open(':memory:', inMemory, debug)
+    close(dbId, debug)
   })
 })


### PR DESCRIPTION
eslint --fix with the prettier/prettier rule removes semicolons that
the repo prettier config (semi: false) forbids. yarn lint in npm/napi
now passes. Formatting-only change.