### PR TITLE
chore: update Rust toolchain to 1.96.0

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -45,8 +45,8 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |-
               set -e &&
-              rustup install 1.88.0 &&
-              rustup default 1.88.0 &&
+              rustup install 1.96.0 &&
+              rustup default 1.96.0 &&
               apt-get update &&
               apt-get -y install protobuf-compiler &&
               yarn build --target x86_64-unknown-linux-gnu &&

--- a/denokv/main.rs
+++ b/denokv/main.rs
@@ -60,7 +60,6 @@ use hyper::client::HttpConnector;
 use hyper_proxy::Intercept;
 use hyper_proxy::Proxy;
 use hyper_proxy::ProxyConnector;
-use log::error;
 use log::info;
 use prost::DecodeError;
 use prost::Message;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
* rust-toolchain.toml: 1.88.0 -> 1.96.0 (latest stable)
* removes a `use log::error` import that rustc 1.96 newly flags as
  unused (call sites use the fully qualified `log::error!` form)

cargo fmt, clippy (-D clippy::all, all targets and features), and the
test suite are clean on the new toolchain. Unblocks moving aws-sdk
crates to current releases, which require rustc >= 1.91.1.