### PR TITLE
chore: upgrade prost to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,15 +1134,21 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1289,15 +1295,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1307,8 +1310,14 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1581,12 +1590,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1841,11 +1850,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.2",
  "indexmap",
 ]
 
@@ -1924,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1934,16 +1944,14 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "bytes",
  "heck",
  "itertools",
  "log",
  "multimap",
- "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
@@ -1955,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1968,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ hex = "0.4"
 http = "1"
 log = "0.4.20"
 num-bigint = "0.4"
-prost = "0.13"
-prost-build = "0.13"
+prost = "0.14"
+prost-build = "0.14"
 rand = "0.8.5"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "stream"] }
 rusqlite = { version = "0.40.0", features = ["fallible_uint"] }

--- a/npm/napi/Cargo.toml
+++ b/npm/napi/Cargo.toml
@@ -19,7 +19,7 @@ rand = "0.8.5"
 rand_distr = "0.3.0"
 tokio = { version = "1.33.0", features = ["full"] }
 anyhow = "1"
-prost = "0.13"
+prost = "0.14"
 once_cell = "1.18.0"
 rusqlite = { version = "0.40.0", features = ["bundled", "fallible_uint"] }
 deno_error = "0.7.0"

--- a/proto/protobuf/com.deno.kv.backup.rs
+++ b/proto/protobuf/com.deno.kv.backup.rs
@@ -10,7 +10,7 @@ pub struct BackupSnapshotRange {
   #[prost(message, repeated, tag = "2")]
   pub metadata_list: ::prost::alloc::vec::Vec<BackupKvPair>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BackupKvPair {
   #[prost(bytes = "vec", tag = "1")]
   pub key: ::prost::alloc::vec::Vec<u8>,
@@ -24,7 +24,7 @@ pub struct BackupMutationRange {
   #[prost(uint64, tag = "2")]
   pub timestamp_ms: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BackupReplicationLogEntry {
   #[prost(bytes = "vec", tag = "1")]
   pub versionstamp: ::prost::alloc::vec::Vec<u8>,

--- a/proto/protobuf/com.deno.kv.datapath.rs
+++ b/proto/protobuf/com.deno.kv.datapath.rs
@@ -33,7 +33,7 @@ pub struct SnapshotReadOutput {
 }
 /// A key range to read. The range is inclusive of the start and exclusive of the
 /// end.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ReadRange {
   /// The first key to read.
   #[prost(bytes = "vec", tag = "1")]
@@ -70,7 +70,7 @@ pub struct AtomicWrite {
   #[prost(message, repeated, tag = "3")]
   pub enqueues: ::prost::alloc::vec::Vec<Enqueue>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct AtomicWriteOutput {
   /// The status of the write.
   #[prost(enumeration = "AtomicWriteStatus", tag = "1")]
@@ -83,7 +83,7 @@ pub struct AtomicWriteOutput {
   pub failed_checks: ::prost::alloc::vec::Vec<u32>,
 }
 /// A mutation to perform.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Check {
   /// The key to check.
   #[prost(bytes = "vec", tag = "1")]
@@ -97,7 +97,7 @@ pub struct Check {
   pub versionstamp: ::prost::alloc::vec::Vec<u8>,
 }
 /// A mutation to perform.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Mutation {
   /// The key to mutate.
   #[prost(bytes = "vec", tag = "1")]
@@ -128,7 +128,7 @@ pub struct Mutation {
   #[prost(bool, tag = "7")]
   pub sum_clamp: bool,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KvValue {
   #[prost(bytes = "vec", tag = "1")]
   pub data: ::prost::alloc::vec::Vec<u8>,
@@ -136,7 +136,7 @@ pub struct KvValue {
   pub encoding: i32,
 }
 /// A key-value entry.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KvEntry {
   /// The key.
   #[prost(bytes = "vec", tag = "1")]
@@ -152,7 +152,7 @@ pub struct KvEntry {
   pub versionstamp: ::prost::alloc::vec::Vec<u8>,
 }
 /// A request to enqueue a message.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Enqueue {
   /// The payload of the message, encoded as a V8 ValueSerializer value.
   #[prost(bytes = "vec", tag = "1")]
@@ -193,14 +193,14 @@ pub struct WatchOutput {
   pub keys: ::prost::alloc::vec::Vec<WatchKeyOutput>,
 }
 /// A key to watch.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WatchKey {
   /// The key to watch.
   #[prost(bytes = "vec", tag = "1")]
   pub key: ::prost::alloc::vec::Vec<u8>,
 }
 /// The response to a watch request for a single key.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WatchKeyOutput {
   /// Whether the value changed since the last watch delivery.
   #[prost(bool, tag = "1")]


### PR DESCRIPTION
* prost, prost-build, prost-derive, prost-types 0.13 -> 0.14
* generated protobuf sources are regenerated with protoc 21.12 (the
  version CI pins); prost-build 0.14 derives Eq and Hash on messages
  without float fields, which is the only generated-code change
* prost::Message appears in public trait bounds of denokv_proto, so
  this is a semver-relevant change for the next release version
* one duplicate enters the lockfile: foldhash 0.1 reappears next to
  0.2 because prost-build's petgraph pins hashbrown ^0.15 (foldhash
  ^0.1) while hashlink/lru use hashbrown 0.16 (foldhash 0.2). This
  is confined to prost-build's build-time graph and is
  upstream-pinned; it goes away when petgraph moves to hashbrown
  0.16+.
