### PR TITLE
fix: send content-type header on data path requests

### DIFF
--- a/npm/src/kv_connect_api.ts
+++ b/npm/src/kv_connect_api.ts
@@ -175,6 +175,7 @@ async function fetchProtobuf(
 ): Promise<Uint8Array | ReadableStream<Uint8Array>> {
   const headers = {
     authorization: `Bearer ${accessToken}`,
+    "content-type": "application/x-protobuf",
     ...(version === 1 ? { "x-transaction-domain-id": databaseId } : {
       "x-denokv-version": version.toString(),
       "x-denokv-database-id": databaseId,

--- a/remote/lib.rs
+++ b/remote/lib.rs
@@ -102,10 +102,14 @@ struct Metadata {
 
 impl Metadata {
   pub fn headers(&self) -> HeaderMap {
-    let mut headers = HeaderMap::with_capacity(3);
+    let mut headers = HeaderMap::with_capacity(4);
     headers.insert(
       "authorization",
       format!("Bearer {}", self.token).try_into().unwrap(),
+    );
+    headers.insert(
+      "content-type",
+      HeaderValue::from_static("application/x-protobuf"),
     );
     match self.version {
       ProtocolVersion::V1 => {


### PR DESCRIPTION
The KV Connect spec requires clients to send a Content-Type header
with the value application/x-protobuf on all data path requests
(proto/kv-connect.md line 194). Neither the Rust remote client nor
the npm client library did, which breaks servers and proxies that
reject protobuf bodies without a content type.

* remote/lib.rs: Metadata::headers() gains the content-type entry
  (the JSON metadata exchange already sent application/json)
* npm/src/kv_connect_api.ts: fetchProtobuf sends the same header for
  all protocol versions

Fixes #81.