### PR TITLE
fix: build the darwin-x64 napi binary for the right architecture

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -32,7 +32,7 @@ jobs:
             target: x86_64-apple-darwin
             build: |
               brew install protobuf
-              yarn build
+              yarn build --target x86_64-apple-darwin
               strip -x *.node
           - host: windows-latest
             build: |
@@ -144,6 +144,9 @@ jobs:
             target: x86_64-pc-windows-msvc
           - host: macos-latest
             target: x86_64-apple-darwin
+            node-arch: x64
+          - host: macos-latest
+            target: aarch64-apple-darwin
         node:
           - '18'
           - '20'
@@ -154,6 +157,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          architecture: ${{ matrix.settings.node-arch }}
           cache: yarn
           cache-dependency-path: ./npm/napi/yarn.lock
       - name: Install dependencies

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -147,6 +147,7 @@ jobs:
             node-arch: x64
           - host: macos-latest
             target: aarch64-apple-darwin
+            node-arch: arm64
         node:
           - '18'
           - '20'


### PR DESCRIPTION
When GitHub switched macos-latest runners to arm64, the
x86_64-apple-darwin matrix entry kept building without an explicit
--target, producing an arm64 binary. The darwin-x64 npm package has
shipped without its .node binary since 0.8.0 as a result, and the
test job could not catch it because it also ran on arm64 hosts and
happily loaded the mislabeled arm64 binary.

* the x86_64-apple-darwin build passes --target explicitly
* its test job runs x64 node via Rosetta (setup-node architecture)
* the aarch64-apple-darwin artifact gains its own native test entry

Fixes #135. Fixes #90.