### PR TITLE
feat: build and publish the napi package for linux arm64

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -51,17 +51,18 @@ jobs:
               apt-get -y install protobuf-compiler &&
               yarn build --target x86_64-unknown-linux-gnu &&
               strip *.node
-          - host: ubuntu-24.04-arm
+          - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
             build: |-
               set -e &&
               rustup install 1.96.0 &&
               rustup default 1.96.0 &&
+              rustup target add aarch64-unknown-linux-gnu &&
               apt-get update &&
               apt-get -y install protobuf-compiler &&
               yarn build --target aarch64-unknown-linux-gnu &&
-              strip *.node
+              aarch64-unknown-linux-gnu-strip *.node
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -51,6 +51,17 @@ jobs:
               apt-get -y install protobuf-compiler &&
               yarn build --target x86_64-unknown-linux-gnu &&
               strip *.node
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
+            build: |-
+              set -e &&
+              rustup install 1.96.0 &&
+              rustup default 1.96.0 &&
+              apt-get update &&
+              apt-get -y install protobuf-compiler &&
+              yarn build --target aarch64-unknown-linux-gnu &&
+              strip *.node
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
@@ -175,6 +186,40 @@ jobs:
         working-directory: ./npm/napi
       - name: Test bindings
         run: yarn test
+        working-directory: ./npm/napi
+  test-linux-arm64-gnu-binding:
+    name: Test bindings on Linux-arm64-gnu - node@${{ matrix.node }}
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - '18'
+          - '20'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: yarn
+          cache-dependency-path: ./npm/napi/yarn.lock
+      - name: Install dependencies
+        run: yarn install
+        working-directory: ./npm/napi
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-aarch64-unknown-linux-gnu
+          path: ./npm/napi
+      - name: List packages
+        run: ls -R .
+        shell: bash
+        working-directory: ./npm/napi
+      - name: Test bindings
+        run: docker run --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim yarn test
         working-directory: ./npm/napi
   test-linux-x64-gnu-binding:
     name: Test bindings on Linux-x64-gnu - node@${{ matrix.node }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -263,6 +263,7 @@ jobs:
     needs:
       - test-macOS-windows-binding
       - test-linux-x64-gnu-binding
+      - test-linux-arm64-gnu-binding
     steps:
       - uses: actions/checkout@v4
       - name: Setup node

--- a/npm/napi/npm/linux-arm64-gnu/package.json
+++ b/npm/napi/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@deno/kv-linux-arm64-gnu",
+  "version": "0.0.0-local",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "deno-kv-napi.linux-arm64-gnu.node",
+  "files": [
+    "deno-kv-napi.linux-arm64-gnu.node"
+  ],
+  "description": "A Deno KV client library optimized for Node.js",
+  "keywords": [
+    "deno",
+    "kv",
+    "napi-rs",
+    "NAPI",
+    "N-API",
+    "Rust",
+    "node-addon",
+    "node-addon-api"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 18"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/denoland/denokv.git",
+    "directory": "npm/napi"
+  },
+  "libc": [
+    "glibc"
+  ]
+}

--- a/npm/napi/package.json
+++ b/npm/napi/package.json
@@ -23,7 +23,8 @@
     "triples": {
       "defaults": true,
       "additional": [
-        "aarch64-apple-darwin"
+        "aarch64-apple-darwin",
+        "aarch64-unknown-linux-gnu"
       ]
     }
   },

--- a/npm/src/scripts/build_npm.ts
+++ b/npm/src/scripts/build_npm.ts
@@ -71,14 +71,20 @@ await build({
     repository: {
       type: "git",
       url: "https://github.com/denoland/denokv.git",
-      directory: "npm"
+      directory: "npm",
     },
     bugs: {
       url: "https://github.com/denoland/denokv/issues",
     },
     homepage: "https://github.com/denoland/denokv/tree/main/npm",
     optionalDependencies: Object.fromEntries(
-      ["win32-x64-msvc", "darwin-x64", "linux-x64-gnu", "darwin-arm64"].map(
+      [
+        "win32-x64-msvc",
+        "darwin-x64",
+        "linux-x64-gnu",
+        "linux-arm64-gnu",
+        "darwin-arm64",
+      ].map(
         (v) => [`${napi.packageName}-${v}`, napi.packageVersion],
       ),
     ),

--- a/npm/src/scripts/generate_napi_index.ts
+++ b/npm/src/scripts/generate_napi_index.ts
@@ -113,6 +113,22 @@ switch (platform) {
           }
         }
         break
+      case 'arm64':
+        if (isMusl()) {
+            throw new Error(\`Unsupported architecture on Linux: \${arch} (musl)\`)
+        } else {
+          localFileExisted = existsSync(join(__dirname, '${napiArtifactName}.linux-arm64-gnu.node'))
+          try {
+            if (localFileExisted) {
+              nativeBinding = require('./${napiArtifactName}.linux-arm64-gnu.node')
+            } else {
+              nativeBinding = require('${napiPackageName}-linux-arm64-gnu')
+            }
+          } catch (e) {
+            loadError = e
+          }
+        }
+        break
       default:
         throw new Error(\`Unsupported architecture on Linux: \${arch}\`)
     }


### PR DESCRIPTION
Adds an aarch64-unknown-linux-gnu entry to the napi build matrix
(native arm64 runner with the napi-rs debian-aarch64 image), a
matching test job, the @deno/kv-linux-arm64-gnu platform package,
and the linux arm64 loader branch in the generated napi index.

Fixes #71.