### PR TITLE
feat: export KvU64 from the npm package

### DIFF
--- a/npm/src/kv_u64_test.ts
+++ b/npm/src/kv_u64_test.ts
@@ -47,16 +47,8 @@ Deno.test({
     assertEquals(u.value, 5n);
 
     const kv = await openKv(undefined, { implementation: "in-memory" });
-    await kv.atomic().mutate({
-      type: "sum",
-      key: ["u"],
-      value: new KvU64(2n),
-    }).commit();
-    await kv.atomic().mutate({
-      type: "sum",
-      key: ["u"],
-      value: new KvU64(3n),
-    }).commit();
+    await kv.set(["u"], new KvU64(2n));
+    await kv.atomic().sum(["u"], 3n).commit();
     const entry = await kv.get(["u"]);
     assertEquals((entry.value as { value: bigint }).value, 5n);
     kv.close();

--- a/npm/src/kv_u64_test.ts
+++ b/npm/src/kv_u64_test.ts
@@ -38,3 +38,27 @@ Deno.test({
       );
   },
 });
+
+Deno.test({
+  name: "KvU64 is exported from the package entrypoint",
+  fn: async () => {
+    const { KvU64, openKv } = await import("./npm.ts");
+    const u = new KvU64(5n);
+    assertEquals(u.value, 5n);
+
+    const kv = await openKv(undefined, { implementation: "in-memory" });
+    await kv.atomic().mutate({
+      type: "sum",
+      key: ["u"],
+      value: new KvU64(2n),
+    }).commit();
+    await kv.atomic().mutate({
+      type: "sum",
+      key: ["u"],
+      value: new KvU64(3n),
+    }).commit();
+    const entry = await kv.get(["u"]);
+    assertEquals((entry.value as { value: bigint }).value, 5n);
+    kv.close();
+  },
+});

--- a/npm/src/npm.ts
+++ b/npm/src/npm.ts
@@ -17,6 +17,7 @@ export * from "./napi_based.ts";
 export * from "./remote.ts";
 export * from "./in_memory.ts";
 export * from "./kv_types.ts";
+export { _KvU64 as KvU64 } from "./kv_u64.ts";
 export { makeLimitedV8Serializer, UnknownV8 } from "./v8.ts";
 
 export type KvImplementation = "in-memory" | "sqlite" | "remote";


### PR DESCRIPTION
The package returned KvU64 instances from u64 reads but offered no
way to construct one or reference its type. The class is now
exported under the same name as the built-in Deno.KvU64.

Fixes #88.