### PR TITLE
fix: match native Deno.Kv.list selector validation

### DIFF
--- a/npm/src/kv_util.ts
+++ b/npm/src/kv_util.ts
@@ -1,6 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 
-import { decodeHex, encodeHex } from "./bytes.ts";
+import { compareBytes, decodeHex, encodeHex, equalBytes } from "./bytes.ts";
 import {
   checkExpireIn,
   checkKeyNotEmpty,
@@ -22,6 +22,7 @@ import {
   KvListSelector,
   KvMutation,
 } from "./kv_types.ts";
+import { packKey } from "./kv_key.ts";
 import { _KvU64 } from "./kv_u64.ts";
 import { defer, Deferred } from "./proto/runtime/async/observer.ts";
 import {
@@ -99,13 +100,50 @@ export function unpackCursor(str: string): Cursor {
   throw new Error(`Invalid cursor`);
 }
 
-export function checkListSelector(selector: KvListSelector) {
+export function checkListSelector(selector: KvListSelector): KvListSelector {
   if (!isRecord(selector)) {
     throw new TypeError(`Bad selector: ${JSON.stringify(selector)}`);
   }
-  if ("prefix" in selector && "start" in selector && "end" in selector) {
+  const { prefix, start, end } = selector as {
+    prefix?: KvKey;
+    start?: KvKey;
+    end?: KvKey;
+  };
+  if (prefix !== undefined) {
+    if (start !== undefined && end !== undefined) {
+      throw new TypeError(
+        `Selector can not specify both 'start' and 'end' key when specifying 'prefix'`,
+      );
+    }
+    if (start !== undefined) {
+      checkKeyInPrefixKeyspace(start, prefix, "Start");
+      return { prefix, start };
+    }
+    if (end !== undefined) {
+      checkKeyInPrefixKeyspace(end, prefix, "End");
+      return { prefix, end };
+    }
+    return { prefix };
+  }
+  if (start !== undefined && end !== undefined) {
+    if (compareBytes(packKey(start), packKey(end)) > 0) {
+      throw new TypeError(`Start key is greater than end key`);
+    }
+    return { start, end };
+  }
+  throw new TypeError(
+    `Selector must specify either 'prefix' or both 'start' and 'end' key`,
+  );
+}
+
+function checkKeyInPrefixKeyspace(key: KvKey, prefix: KvKey, which: string) {
+  const keyBytes = packKey(key);
+  const prefixBytes = packKey(prefix);
+  const inKeyspace = keyBytes.length > prefixBytes.length &&
+    equalBytes(keyBytes.subarray(0, prefixBytes.length), prefixBytes);
+  if (!inKeyspace) {
     throw new TypeError(
-      `Selector can not specify both 'start' and 'end' key when specifying 'prefix'`,
+      `${which} key is not in the keyspace defined by prefix`,
     );
   }
 }
@@ -331,7 +369,7 @@ export abstract class BaseKv implements Kv {
     options: KvListOptions = {},
   ): KvListIterator<T> {
     this.checkOpen("list");
-    checkListSelector(selector);
+    selector = checkListSelector(selector);
     options = checkListOptions(options);
     const outCursor = new CursorHolder();
     const generator: AsyncGenerator<KvEntry<T>> = this.listStream(

--- a/npm/src/kv_util_test.ts
+++ b/npm/src/kv_util_test.ts
@@ -1,0 +1,94 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/assert_equals.ts";
+import { assertThrows } from "https://deno.land/std@0.208.0/assert/assert_throws.ts";
+import { checkListSelector } from "./kv_util.ts";
+
+Deno.test({
+  name: "checkListSelector ignores selector keys with undefined values",
+  fn: () => {
+    assertEquals(
+      checkListSelector(
+        { prefix: ["users"], start: undefined, end: undefined } as never,
+      ),
+      { prefix: ["users"] },
+    );
+    assertEquals(
+      checkListSelector(
+        { start: ["a"], end: ["b"], prefix: undefined } as never,
+      ),
+      { start: ["a"], end: ["b"] },
+    );
+  },
+});
+
+Deno.test({
+  name: "checkListSelector requires range keys to be in the prefix keyspace",
+  fn: () => {
+    assertThrows(
+      () => checkListSelector({ prefix: ["users"], end: ["C"] }),
+      TypeError,
+      "End key is not in the keyspace defined by prefix",
+    );
+    assertThrows(
+      () => checkListSelector({ prefix: ["users"], start: ["C"] }),
+      TypeError,
+      "Start key is not in the keyspace defined by prefix",
+    );
+    // a key equal to the prefix is not in its keyspace
+    assertThrows(
+      () => checkListSelector({ prefix: ["users"], start: ["users"] }),
+      TypeError,
+      "Start key is not in the keyspace defined by prefix",
+    );
+    assertEquals(
+      checkListSelector({ prefix: ["users"], end: ["users", "C"] }),
+      { prefix: ["users"], end: ["users", "C"] },
+    );
+  },
+});
+
+Deno.test({
+  name: "checkListSelector rejects incomplete selectors",
+  fn: () => {
+    for (const selector of [{ start: [10] }, { end: [10] }, {}]) {
+      assertThrows(
+        () => checkListSelector(selector as never),
+        TypeError,
+        "Selector must specify either 'prefix' or both 'start' and 'end' key",
+      );
+    }
+  },
+});
+
+Deno.test({
+  name: "checkListSelector rejects a start key greater than the end key",
+  fn: () => {
+    assertThrows(
+      () => checkListSelector({ start: ["b"], end: ["a"] }),
+      TypeError,
+      "Start key is greater than end key",
+    );
+  },
+});
+
+Deno.test({
+  name: "list accepts selectors with undefined range keys",
+  fn: async () => {
+    const { openKv } = await import("./npm.ts");
+    const kv = await openKv(undefined, { implementation: "in-memory" });
+    await kv.set(["users", "a"], 1);
+    const entries = [];
+    for await (
+      const entry of kv.list({
+        prefix: ["users"],
+        start: undefined,
+        end: undefined,
+      } as never)
+    ) {
+      entries.push(entry.key);
+    }
+    assertEquals(entries, [["users", "a"]]);
+    kv.close();
+  },
+});


### PR DESCRIPTION
The npm package's list selector handling diverged from the native
implementation in three ways (#130):

* selector keys with undefined values were treated as present
  because presence was tested with the 'in' operator, so
  { prefix, start: undefined, end: undefined } was rejected
* range keys outside the keyspace defined by the prefix were
  accepted instead of raising the native TypeError
* incomplete selectors ({ start } only, { end } only, {}) crashed
  with a confusing 'flatMap of undefined' error instead of the
  native 'Selector must specify either prefix or both start and
  end key' TypeError

checkListSelector now normalizes the selector exactly like the
native JS layer (dropping undefined-valued keys) and applies the
native byte-level keyspace and ordering checks, returning the
normalized selector that the list implementations consume.

Fixes #130.