### PR TITLE
fix: deflake the queue delivery e2e test

### DIFF
--- a/npm/src/e2e.ts
+++ b/npm/src/e2e.ts
@@ -643,7 +643,10 @@ export async function endToEnd(
       kv.listenQueue((v) => {
         received.push(v);
       });
-      await sleep(napi ? 1000 : type === "deno" ? 100 : 50);
+      const deadline = Date.now() + 10_000;
+      while (received.length === 0 && Date.now() < deadline) {
+        await sleep(25);
+      }
       assertEquals(received, ["later"]);
 
       kv.close();


### PR DESCRIPTION
The test slept a fixed 50-1000ms after reopening the database and
asserted the queued message had been delivered, which fails on slow
CI runners (observed on the publish dry-run job). It now polls for
delivery with a 10 second deadline, keeping the same assertion.