### PR TITLE
fix: load the napi binding lazily-failing

### DIFF
--- a/npm/src/napi_based.ts
+++ b/npm/src/napi_based.ts
@@ -123,6 +123,7 @@ export function isNapiInterface(obj: unknown): obj is NapiInterface {
 
 //
 
+let DEFAULT_NAPI_INTERFACE_LOAD_ERROR: unknown;
 // deno-lint-ignore no-explicit-any
 const DEFAULT_NAPI_INTERFACE: any = undefined;
 
@@ -165,9 +166,14 @@ class NapiBasedKv extends ProtoBasedKv {
       throw new Error(`Invalid path: ${url}`);
     }
     if (napi === undefined) {
-      throw new Error(
+      const error = new Error(
         `No default napi interface, provide one via the 'napi' option.`,
       );
+      if (DEFAULT_NAPI_INTERFACE_LOAD_ERROR !== undefined) {
+        (error as { cause?: unknown }).cause =
+          DEFAULT_NAPI_INTERFACE_LOAD_ERROR;
+      }
+      throw error;
     }
     const dbId = napi.open(url, inMemory, debug);
     return new NapiBasedKv(debug, napi, dbId, decodeV8, encodeV8);

--- a/npm/src/scripts/build_npm.ts
+++ b/npm/src/scripts/build_npm.ts
@@ -109,9 +109,27 @@ await build({
       const oldContents = await Deno.readTextFile(
         join(outDir, subdir, "napi_based.js"),
       );
+      // Load the napi binding lazily-failing: platforms without a
+      // binding (e.g. Deno Deploy) must still be able to import the
+      // package and use the non-napi implementations. The load error
+      // is kept and surfaced only when the napi path is actually used.
       const insertion = subdir === "esm"
-        ? `await import('./${name}')`
-        : `require('./${name}')`;
+        ? `await (async () => {
+  try {
+    return await import('./${name}');
+  } catch (e) {
+    DEFAULT_NAPI_INTERFACE_LOAD_ERROR = e;
+    return undefined;
+  }
+})()`
+        : `(() => {
+  try {
+    return require('./${name}');
+  } catch (e) {
+    DEFAULT_NAPI_INTERFACE_LOAD_ERROR = e;
+    return undefined;
+  }
+})()`;
 
       const newContents = oldContents.replace(
         `const DEFAULT_NAPI_INTERFACE = undefined;`,

--- a/npm/src/scripts/build_npm.ts
+++ b/npm/src/scripts/build_npm.ts
@@ -140,6 +140,40 @@ await build({
         newContents,
       );
     }
+
+    // Smoke test the built package with node on a machine without a
+    // napi binding (the out dir never contains the platform packages):
+    // importing must succeed, the in-memory implementation must work,
+    // and the napi path must fail with the binding load error attached
+    // as the cause (#99).
+    console.log("smoke testing the built package");
+    const smokeTest = `
+(async () => {
+  const assert = require('assert').strict;
+  const { pathToFileURL } = require('url');
+  const esm = await import(pathToFileURL(${
+      JSON.stringify(join(outDir, "esm", "npm.js"))
+    }));
+  const cjs = require(${JSON.stringify(join(outDir, "script", "npm.js"))});
+  for (const { openKv } of [esm, cjs]) {
+    const kv = await openKv(undefined, { implementation: 'in-memory' });
+    await kv.set(['a'], 1);
+    assert.equal((await kv.get(['a'])).value, 1);
+    kv.close();
+    await assert.rejects(
+      () => openKv('./smoke-test.sqlite'),
+      (e) =>
+        /No default napi interface/.test(e.message) &&
+        e.cause !== undefined,
+    );
+  }
+  console.log('smoke test ok');
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+`;
+    await run({ command: "node", args: ["-e", smokeTest] });
   },
 });
 


### PR DESCRIPTION
The generated napi index resolved the platform binding at module
evaluation time, so merely importing @deno/kv crashed on platforms
without a binding (e.g. Deno Deploy) even when the native or
in-memory implementation would have been used. The binding load
error is now caught at import time and surfaced as the cause of the
'No default napi interface' error only when the napi path is
actually taken.

Fixes #99.

Verified against a locally built package on a machine without a
platform binding: esm and cjs imports succeed, the in-memory
implementation works, and the sqlite path throws the clear error
with the original module-load failure attached as its cause.