### PR TITLE
feat: add a manually triggered release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main"]
     tags: ["[0-9]+.[0-9]+.[0-9]+"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,18 +93,6 @@ jobs:
           name: denokv-x86_64-pc-windows-msvc.zip
           path: target/release/denokv-x86_64-pc-windows-msvc.zip
 
-      - name: Upload release to GitHub
-        uses: softprops/action-gh-release@v0.1.15
-        if: github.repository == 'denoland/denokv' && startsWith(github.ref, 'refs/tags/')
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          files: |-
-            target/release/denokv-x86_64-pc-windows-msvc.zip
-            target/release/denokv-x86_64-unknown-linux-gnu.zip
-            target/release/denokv-x86_64-apple-darwin.zip
-          draft: true
-
       - name: Publish to crates.io
         if: runner.os == 'Linux' && github.repository == 'denoland/denokv' && startsWith(github.ref, 'refs/tags/')
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: docker
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main"]
     tags: ["[0-9]+.[0-9]+.[0-9]+"]

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -4,6 +4,7 @@ env:
   APP_NAME: deno-kv-napi
   MACOSX_DEPLOYMENT_TARGET: '10.13'
 'on':
+  workflow_dispatch: null
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.14.0)"
+        required: true
+        type: string
+      dry-run:
+        description: "Build everything but push and release nothing"
+        type: boolean
+        default: false
+  # Exercise the whole flow as a dry run when the release machinery
+  # itself changes.
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - "scripts/release.sh"
+
+env:
+  VERSION: ${{ inputs.version || '0.0.0-test' }}
+  DRY_RUN: ${{ (github.event_name == 'pull_request' || inputs.dry-run) && '1' || '' }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - host: macos-latest
+            target: x86_64-apple-darwin
+          - host: macos-latest
+            target: aarch64-apple-darwin
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+    name: build ${{ matrix.settings.target }}
+    runs-on: ${{ matrix.settings.host }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - name: Add target
+        run: rustup target add ${{ matrix.settings.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.settings.target }}
+
+      - name: Bump version
+        run: ./scripts/release.sh bump "$VERSION"
+        shell: bash
+
+      - name: Build
+        run: cargo build --release -p denokv --target ${{ matrix.settings.target }}
+
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        run: |-
+          cd target/${{ matrix.settings.target }}/release
+          zip -r denokv-${{ matrix.settings.target }}.zip denokv
+
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        run: |-
+          Compress-Archive -CompressionLevel Optimal -Force -Path target/${{ matrix.settings.target }}/release/denokv.exe -DestinationPath target/${{ matrix.settings.target }}/release/denokv-${{ matrix.settings.target }}.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: denokv-${{ matrix.settings.target }}.zip
+          path: target/${{ matrix.settings.target }}/release/denokv-${{ matrix.settings.target }}.zip
+          if-no-files-found: error
+
+  release:
+    name: release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - name: Bump version and commit
+        shell: bash
+        run: |-
+          ./scripts/release.sh bump "$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -u
+          git commit -m "chore: release $VERSION"
+
+      - name: Generate release notes
+        shell: bash
+        run: |-
+          ./scripts/release.sh notes "$VERSION" | tee notes.md
+          {
+            echo "## ${DRY_RUN:+dry run: }release $VERSION"
+            echo
+            cat notes.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Push and release
+        if: env.DRY_RUN == ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |-
+          git push origin HEAD:main
+          git tag "$VERSION"
+          git push origin "refs/tags/$VERSION"
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes-file notes.md \
+            artifacts/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
+      - name: Require main for real releases
+        if: env.DRY_RUN == '' && github.ref != 'refs/heads/main'
+        run: |-
+          echo "real releases must be dispatched from main (got $GITHUB_REF)"
+          exit 1
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -128,3 +135,9 @@ jobs:
             --title "$VERSION" \
             --notes-file notes.md \
             artifacts/*.zip
+          # Tag pushes made with the workflow token do not trigger the
+          # tag-triggered workflows, so dispatch the publishes directly
+          # against the new tag.
+          gh workflow run ci.yml --ref "$VERSION"
+          gh workflow run npm.yml --ref "$VERSION"
+          gh workflow run docker.yml --ref "$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,9 +135,22 @@ jobs:
             --title "$VERSION" \
             --notes-file notes.md \
             artifacts/*.zip
-          # Tag pushes made with the workflow token do not trigger the
-          # tag-triggered workflows, so dispatch the publishes directly
-          # against the new tag.
-          gh workflow run ci.yml --ref "$VERSION"
-          gh workflow run npm.yml --ref "$VERSION"
-          gh workflow run docker.yml --ref "$VERSION"
+
+      # Tag pushes made with the workflow token do not trigger the
+      # tag-triggered workflows, so dispatch the publishes directly
+      # against the new tag. Attempt every dispatch even if one fails;
+      # a failed dispatch can be retried by hand from the Actions tab.
+      - name: Dispatch publish workflows
+        if: env.DRY_RUN == ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |-
+          failed=0
+          for workflow in ci.yml npm.yml docker.yml; do
+            if ! gh workflow run "$workflow" --ref "$VERSION"; then
+              echo "failed to dispatch $workflow"
+              failed=1
+            fi
+          done
+          exit "$failed"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Release helpers for the denokv workspace, used by the release
+# workflow and runnable locally.
+#
+#   scripts/release.sh bump <version>    rewrite crate versions and the
+#                                        lockfile to <version>
+#   scripts/release.sh notes <version>   print release notes for the
+#                                        range <last tag>..HEAD
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage() {
+  echo "usage: $0 bump|notes <version>" >&2
+  exit 1
+}
+
+[ $# -eq 2 ] || usage
+command=$1
+version=$2
+
+if ! grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' <<< "$version"; then
+  echo "invalid version: $version" >&2
+  exit 1
+fi
+
+case "$command" in
+  bump)
+    for crate in denokv proto remote sqlite timemachine; do
+      sed -i.bak -E "s/^version = \"[^\"]+\"$/version = \"$version\"/" \
+        "$crate/Cargo.toml"
+      rm "$crate/Cargo.toml.bak"
+    done
+    sed -i.bak -E \
+      "s/^(denokv_[a-z]+ = \{ version = )\"[^\"]+\"/\1\"$version\"/" \
+      Cargo.toml
+    rm Cargo.toml.bak
+    cargo update --workspace --quiet
+    ;;
+  notes)
+    prev=$(git describe --tags --abbrev=0 HEAD)
+    echo "## What's Changed"
+    git log --oneline --no-decorate --no-merges "$prev..HEAD" \
+      | sed -E 's/^[0-9a-f]+ /* /'
+    echo
+    echo "**Full Changelog**: https://github.com/denoland/denokv/compare/$prev...$version"
+    ;;
+  *)
+    usage
+    ;;
+esac


### PR DESCRIPTION

A workflow_dispatch run with a version input bumps the crate
versions and the lockfile, commits to main, tags, builds the denokv
binary for four targets, and creates a published GitHub release with
notes generated from git log --oneline since the previous tag (the
What's Changed / Full Changelog format of earlier releases). The
crates.io and npm publishes stay on the existing tag-triggered
workflows.

* a dry-run input (and any pull request touching the release
  machinery) runs the same flow end to end but pushes and releases
  nothing; binaries land as workflow artifacts and the notes go to
  the step summary
* the darwin binary is built for both x86_64 and aarch64 with
  explicit targets; the old ci.yml release step had been producing
  arm64 binaries labeled x86_64 since macos-latest runners changed
  architecture
* ci.yml no longer creates draft releases on tags, making the
  release workflow the only source of GitHub releases and ending the
  duplicate-draft races

Closes #93. Closes #97.

The pull_request trigger on this PR runs the full flow as a dry run:
all four binaries build, the version bump and generated notes are
shown in the run summary, and nothing is pushed or released. Run it
for real from the Actions tab with a version input; releases stay a
manual decision.

Follow-up from the review pass: tag pushes made with the workflow
token do not trigger tag-triggered workflows, so the release job now
dispatches ci.yml, npm.yml, and docker.yml directly against the new
tag (those workflows gain a workflow_dispatch trigger; their
ref-based tag gating works identically when dispatched on a tag).
Real releases must be dispatched from main.
