### PR TITLE
feat: release linux arm64 binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
         settings:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - host: macos-latest
             target: x86_64-apple-darwin
           - host: macos-latest


### PR DESCRIPTION
Adds aarch64-unknown-linux-gnu to the release build matrix on the
arm64 hosted runner; release archives now cover five targets. The
pull_request dry run on this PR builds all five as proof.