### PR TITLE
chore(deps): bump shell-quote to 1.8.4 in npm/napi

### DIFF
--- a/npm/napi/yarn.lock
+++ b/npm/napi/yarn.lock
@@ -4140,9 +4140,9 @@ __metadata:
   linkType: hard
 
 "shell-quote@npm:^1.6.1":
-  version: 1.8.1
-  resolution: "shell-quote@npm:1.8.1"
-  checksum: 8cec6fd827bad74d0a49347057d40dfea1e01f12a6123bf82c4649f3ef152fc2bc6d6176e6376bffcd205d9d0ccb4f1f9acae889384d20baff92186f01ea455a
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* `shell-quote` 1.8.1 → 1.8.4 — fixes failure to escape newlines in
  object `.op` values, allowing command injection
  (GHSA-w7jw-789q-3m8p, critical)

Transitive dev-only dependency via `npm-run-all`; the existing
`^1.6.1` range already permits the patched release, so only the
`npm/napi/yarn.lock` resolution changes.