### PR TITLE
Add KV Connect protocol v4: multiplexed watch channel over WebSocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,7 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -593,8 +594,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -633,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -871,6 +874,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deno_error"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,7 +929,7 @@ dependencies = [
  "log",
  "num-bigint",
  "prost",
- "rand",
+ "rand 0.8.6",
  "reqwest",
  "rusqlite",
  "serde",
@@ -928,6 +937,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "url",
  "uuid",
  "v8_valueserializer",
@@ -962,7 +972,7 @@ dependencies = [
  "http 1.4.1",
  "log",
  "prost",
- "rand",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_json",
@@ -986,7 +996,7 @@ dependencies = [
  "hex",
  "log",
  "num-bigint",
- "rand",
+ "rand 0.8.6",
  "rusqlite",
  "serde_json",
  "thiserror 2.0.18",
@@ -1272,6 +1282,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -1993,14 +2015,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2010,7 +2048,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2019,7 +2067,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.11",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2108,7 +2165,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.11",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2609,6 +2666,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,6 +2779,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.1",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2763,7 +2848,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.11",
  "serde",
 ]
 
@@ -2814,6 +2899,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3046,6 +3140,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ aws-config = { version = "1.8", default-features = false, features = ["behavior-
 aws-sdk-s3 = { version = "1.135", default-features = false, features = ["rt-tokio"] }
 aws-smithy-http-client = { version = "1.1.13", features = ["rustls-ring"] }
 aws-smithy-runtime-api = "1"
-axum = { version = "0.8", features = ["macros", "http2"] }
+axum = { version = "0.8", features = ["macros", "http2", "ws"] }
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
 clap = { version = "4", features = ["derive", "env"] }

--- a/denokv/Cargo.toml
+++ b/denokv/Cargo.toml
@@ -44,6 +44,7 @@ deno_error.workspace = true
 
 [dev-dependencies]
 bytes.workspace = true
+tokio-tungstenite = "0.29"
 denokv_remote.workspace = true
 http.workspace = true
 num-bigint.workspace = true

--- a/denokv/main.rs
+++ b/denokv/main.rs
@@ -13,6 +13,10 @@ use aws_smithy_runtime_api::client::http::SharedHttpConnector;
 use axum::body::Body;
 use axum::body::Bytes;
 use axum::debug_handler;
+use axum::extract::ws::CloseFrame;
+use axum::extract::ws::Message as WsMessage;
+use axum::extract::ws::WebSocket;
+use axum::extract::ws::WebSocketUpgrade;
 use axum::extract::FromRequest;
 use axum::extract::State;
 use axum::http::HeaderMap;
@@ -22,6 +26,7 @@ use axum::middleware;
 use axum::middleware::Next;
 use axum::response::IntoResponse;
 use axum::response::Response;
+use axum::routing::get;
 use axum::routing::post;
 use axum::Json;
 use axum::Router;
@@ -46,6 +51,7 @@ use denokv_proto::EndpointInfo;
 use denokv_proto::MetadataExchangeRequest;
 use denokv_proto::ReadRange;
 use denokv_proto::SnapshotReadOptions;
+use denokv_proto::WatchKeyOutput;
 use denokv_sqlite::Connection;
 use denokv_sqlite::Sqlite;
 use denokv_sqlite::SqliteBackendError;
@@ -235,6 +241,7 @@ async fn run_serve(
     .route("/snapshot_read", post(snapshot_read_endpoint))
     .route("/atomic_write", post(atomic_write_endpoint))
     .route("/watch", post(watch_endpoint))
+    .route("/watch_channel", get(watch_channel_endpoint))
     .route_layer(middleware::from_fn_with_state(
       state.clone(),
       authentication_middleware,
@@ -378,7 +385,9 @@ async fn metadata_endpoint(
   let Ok(req) = serde_json::from_slice::<MetadataExchangeRequest>(&body) else {
     return Err(ApiError::MinumumProtocolVersion);
   };
-  let version = if req.supported_versions.contains(&3) {
+  let version = if req.supported_versions.contains(&4) {
+    4
+  } else if req.supported_versions.contains(&3) {
     3
   } else if req.supported_versions.contains(&2) {
     2
@@ -424,7 +433,10 @@ async fn authentication_middleware(
   else {
     return Err(ApiError::InvalidProtocolVersion);
   };
-  if protocol_version != "2" && protocol_version != "3" {
+  if protocol_version != "2"
+    && protocol_version != "3"
+    && protocol_version != "4"
+  {
     return Err(ApiError::InvalidProtocolVersion);
   }
   let Some(authorization) = req
@@ -517,6 +529,141 @@ async fn watch_endpoint(
     .headers_mut()
     .insert("content-type", "application/octet-stream".parse().unwrap());
   Ok(res)
+}
+
+/// Maximum number of keys that may be watched concurrently on one watch
+/// channel. Exceeding it closes the channel with close code 1008.
+const WATCH_CHANNEL_MAX_KEYS: usize = 1024;
+
+async fn watch_channel_endpoint(
+  State(state): State<AppState>,
+  headers: HeaderMap,
+  ws: WebSocketUpgrade,
+) -> Result<impl IntoResponse, ApiError> {
+  // Watch channels exist since protocol version 4; the shared
+  // authentication middleware also accepts versions 2 and 3.
+  if headers
+    .get("x-denokv-version")
+    .and_then(|v| v.to_str().ok())
+    != Some("4")
+  {
+    return Err(ApiError::InvalidProtocolVersion);
+  }
+  Ok(ws.on_upgrade(move |socket| async move {
+    watch_channel_connection(socket, state).await;
+  }))
+}
+
+async fn watch_channel_connection(socket: WebSocket, state: AppState) {
+  use futures::FutureExt;
+  use futures::SinkExt;
+
+  let (mut ws_tx, mut ws_rx) = socket.split();
+
+  // The channel state machine tracks what the client has been told per
+  // key; the sqlite watcher is rebuilt whenever the key set grows, and its
+  // initial output (everything marked changed) is diffed by the state
+  // machine so the client only receives what it does not already know.
+  type SendWatchStream = std::pin::Pin<
+    Box<
+      dyn futures::Stream<
+          Item = Result<Vec<WatchKeyOutput>, deno_error::JsErrorBox>,
+        > + Send,
+    >,
+  >;
+  let mut channel = denokv_proto::watch_channel_server::WatchChannelServer::new(
+    WATCH_CHANNEL_MAX_KEYS,
+  );
+  // The key list of the current watcher. Removals intentionally leave the
+  // watcher (and this list) untouched — outputs for removed keys are
+  // filtered out by the state machine — so it can lag the watched key set
+  // until the next add.
+  let mut watched_keys: Vec<Vec<u8>> = Vec::new();
+  let mut watcher: Option<SendWatchStream> = None;
+
+  let mut ping = tokio::time::interval(std::time::Duration::from_secs(5));
+  ping.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+  loop {
+    tokio::select! {
+      message = ws_rx.next() => {
+        let Some(Ok(message)) = message else {
+          return;
+        };
+        // Apply this message and any further immediately-available ones,
+        // so a burst of adds (e.g. a client registering all its keys on
+        // connect) triggers one watcher rebuild instead of one per key.
+        let mut keys_changed = false;
+        let mut message = Some(message);
+        loop {
+          let close_reason = match message.take().unwrap() {
+            WsMessage::Binary(bytes) => {
+              use denokv_proto::watch_channel_server::ClientMessageEffect;
+              match channel.apply_client_message(&bytes) {
+                ClientMessageEffect::KeysChanged => {
+                  keys_changed = true;
+                  None
+                }
+                ClientMessageEffect::None => None,
+                ClientMessageEffect::Reject(reason) => Some(reason),
+              }
+            }
+            WsMessage::Text(_) => Some("text messages are not allowed"),
+            WsMessage::Close(_) => return,
+            // Ping/pong are handled by the websocket implementation.
+            _ => None,
+          };
+          if let Some(reason) = close_reason {
+            let _ = ws_tx
+              .send(WsMessage::Close(Some(CloseFrame {
+                code: 1008,
+                reason: reason.into(),
+              })))
+              .await;
+            return;
+          }
+          match ws_rx.next().now_or_never() {
+            Some(Some(Ok(next))) => message = Some(next),
+            Some(Some(Err(_))) | Some(None) => return,
+            None => break,
+          }
+        }
+        if keys_changed {
+          watched_keys = channel.watched_keys();
+          watcher = Some(state.sqlite.watch(watched_keys.clone()));
+        }
+      }
+      outputs = async { watcher.as_mut().unwrap().next().await }, if watcher.is_some() => {
+        let outputs = match outputs {
+          Some(Ok(outputs)) => outputs,
+          // Watcher error or database closing.
+          Some(Err(_)) | None => return,
+        };
+        let states = watched_keys.iter().zip(outputs).filter_map(
+          |(key, output)| match output {
+            WatchKeyOutput::Changed { entry } => {
+              Some((key.clone(), entry.map(pb::KvEntry::from)))
+            }
+            WatchKeyOutput::Unchanged => None,
+          },
+        );
+        if let Some(message) = channel.diff(states) {
+          if ws_tx
+            .send(WsMessage::Binary(message.into()))
+            .await
+            .is_err()
+          {
+            return;
+          }
+        }
+      }
+      _ = ping.tick() => {
+        if ws_tx.send(WsMessage::Ping(Vec::new().into())).await.is_err() {
+          return;
+        }
+      }
+    }
+  }
 }
 
 #[debug_handler]

--- a/denokv/main.rs
+++ b/denokv/main.rs
@@ -600,7 +600,7 @@ async fn watch_channel_connection(socket: WebSocket, state: AppState) {
             WsMessage::Binary(bytes) => {
               use denokv_proto::watch_channel_server::ClientMessageEffect;
               match channel.apply_client_message(&bytes) {
-                ClientMessageEffect::KeysChanged => {
+                ClientMessageEffect::KeyAdded(_) => {
                   keys_changed = true;
                   None
                 }

--- a/denokv/tests/integration.rs
+++ b/denokv/tests/integration.rs
@@ -80,6 +80,91 @@ impl RemoteResponse for ReqwestResponse {
   }
 }
 
+/// Like [`ReqwestClient`], but capable of opening WebSocket connections, so
+/// it negotiates protocol version 4 and watches go through the multiplexed
+/// watch channel.
+#[derive(Clone)]
+struct WsReqwestClient(reqwest::Client);
+
+impl RemoteTransport for WsReqwestClient {
+  type Response = ReqwestResponse;
+  async fn post(
+    &self,
+    url: Url,
+    headers: http::HeaderMap,
+    body: Bytes,
+  ) -> Result<(Url, http::StatusCode, Self::Response), JsErrorBox> {
+    ReqwestClient(self.0.clone()).post(url, headers, body).await
+  }
+
+  fn supports_watch_channel(&self) -> bool {
+    true
+  }
+
+  async fn websocket(
+    &self,
+    url: Url,
+    headers: http::HeaderMap,
+  ) -> Result<
+    (
+      denokv_remote::WebSocketMessageSink,
+      denokv_remote::WebSocketMessageStream,
+    ),
+    JsErrorBox,
+  > {
+    use futures::SinkExt;
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+    use tokio_tungstenite::tungstenite::Message;
+
+    let mut request = url
+      .as_str()
+      .into_client_request()
+      .map_err(|e| JsErrorBox::generic(e.to_string()))?;
+    for (name, value) in headers.iter() {
+      request.headers_mut().insert(name.clone(), value.clone());
+    }
+    let (socket, _response) =
+      tokio_tungstenite::connect_async(request)
+        .await
+        .map_err(|e| JsErrorBox::generic(e.to_string()))?;
+    let (sink, stream) = futures::StreamExt::split(socket);
+    let sink = Box::pin(
+      sink
+        .with(|bytes: Bytes| async move {
+          Ok::<_, tokio_tungstenite::tungstenite::Error>(Message::Binary(bytes))
+        })
+        .sink_map_err(|e: tokio_tungstenite::tungstenite::Error| {
+          JsErrorBox::generic(e.to_string())
+        }),
+    );
+    let stream =
+      Box::pin(futures::stream::unfold(stream, |mut stream| async move {
+        loop {
+          match stream.next().await {
+            Some(Ok(Message::Binary(bytes))) => {
+              return Some((Ok(bytes), stream))
+            }
+            // Control frames are handled by tungstenite.
+            Some(Ok(Message::Ping(_)))
+            | Some(Ok(Message::Pong(_)))
+            | Some(Ok(Message::Frame(_))) => continue,
+            Some(Ok(Message::Text(_))) => {
+              return Some((
+                Err(JsErrorBox::generic("unexpected text message")),
+                stream,
+              ))
+            }
+            Some(Ok(Message::Close(_))) | None => return None,
+            Some(Err(e)) => {
+              return Some((Err(JsErrorBox::generic(e.to_string())), stream))
+            }
+          }
+        }
+      }));
+    Ok((sink, stream))
+  }
+}
+
 fn denokv_exe() -> PathBuf {
   let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
   path.push("../target");
@@ -289,6 +374,235 @@ async fn watch() {
     panic!("Unexpected watch result");
   };
   assert_eq!(entry.key, vec![1]);
+}
+
+async fn set_key<P: RemotePermissions, T: RemoteTransport>(
+  remote: &denokv_remote::Remote<P, T>,
+  key: Vec<u8>,
+  value: u64,
+) {
+  remote
+    .atomic_write(AtomicWrite {
+      checks: vec![],
+      mutations: vec![denokv_proto::Mutation {
+        key,
+        kind: denokv_proto::MutationKind::Set(KvValue::U64(value)),
+        expire_at: None,
+      }],
+      enqueues: vec![],
+    })
+    .await
+    .unwrap()
+    .expect("commit success");
+}
+
+#[tokio::test]
+async fn watch_channel() {
+  let (_child, addr) = start_server().await;
+  let client = WsReqwestClient(reqwest::Client::new());
+  let url = format!("http://localhost:{}", addr.port()).parse().unwrap();
+
+  let metadata_endpoint = denokv_remote::MetadataEndpoint {
+    url,
+    access_token: ACCESS_TOKEN.to_string(),
+  };
+
+  let remote =
+    denokv_remote::Remote::new(client, DummyPermissions, metadata_endpoint);
+
+  set_key(&remote, vec![1], 42).await;
+
+  let mut watch = remote.watch(vec![vec![1], vec![2]]);
+
+  // The first item is a full snapshot: key 1 has a value, key 2 does not.
+  let first = tokio::time::timeout(Duration::from_secs(30), watch.next())
+    .await
+    .expect("no timeout")
+    .unwrap()
+    .expect("watch success");
+  assert_eq!(first.len(), 2);
+  let WatchKeyOutput::Changed { entry: Some(entry) } = &first[0] else {
+    panic!("expected key 1 to have a value: {first:?}");
+  };
+  assert_eq!(entry.key, vec![1]);
+  assert!(matches!(&first[1], WatchKeyOutput::Changed { entry: None }));
+
+  // A write to one key produces an update marking only that key changed.
+  set_key(&remote, vec![2], 1).await;
+  let second = tokio::time::timeout(Duration::from_secs(30), watch.next())
+    .await
+    .expect("no timeout")
+    .unwrap()
+    .expect("watch success");
+  assert!(matches!(&second[0], WatchKeyOutput::Unchanged));
+  let WatchKeyOutput::Changed { entry: Some(entry) } = &second[1] else {
+    panic!("expected key 2 to have a value: {second:?}");
+  };
+  assert_eq!(entry.key, vec![2]);
+
+  // A second watch shares the same channel and gets its own initial
+  // snapshot, while the first watch keeps working.
+  let mut watch2 = remote.watch(vec![vec![1]]);
+  let first2 = tokio::time::timeout(Duration::from_secs(30), watch2.next())
+    .await
+    .expect("no timeout")
+    .unwrap()
+    .expect("watch success");
+  assert_eq!(first2.len(), 1);
+  assert!(matches!(
+    &first2[0],
+    WatchKeyOutput::Changed { entry: Some(_) }
+  ));
+
+  set_key(&remote, vec![1], 43).await;
+  for (name, watch) in [("watch1", &mut watch), ("watch2", &mut watch2)] {
+    loop {
+      let outputs = tokio::time::timeout(Duration::from_secs(30), watch.next())
+        .await
+        .unwrap_or_else(|_| panic!("{name} timed out"))
+        .unwrap()
+        .expect("watch success");
+      // The re-add for watch2's subscription may produce a redundant
+      // update for key 1; skip until the write is observed.
+      if let Some(WatchKeyOutput::Changed { entry: Some(entry) }) =
+        outputs.first()
+      {
+        if matches!(entry.value, KvValue::U64(43)) {
+          break;
+        }
+      }
+    }
+  }
+}
+
+/// A transport that claims WebSocket support but whose connections always
+/// fail — as seen through proxies that strip the Upgrade header.
+#[derive(Clone)]
+struct BrokenWsClient(reqwest::Client);
+
+impl RemoteTransport for BrokenWsClient {
+  type Response = ReqwestResponse;
+  async fn post(
+    &self,
+    url: Url,
+    headers: http::HeaderMap,
+    body: Bytes,
+  ) -> Result<(Url, http::StatusCode, Self::Response), JsErrorBox> {
+    ReqwestClient(self.0.clone()).post(url, headers, body).await
+  }
+
+  fn supports_watch_channel(&self) -> bool {
+    true
+  }
+
+  async fn websocket(
+    &self,
+    _url: Url,
+    _headers: http::HeaderMap,
+  ) -> Result<
+    (
+      denokv_remote::WebSocketMessageSink,
+      denokv_remote::WebSocketMessageStream,
+    ),
+    JsErrorBox,
+  > {
+    Err(JsErrorBox::generic("upgrade blocked"))
+  }
+}
+
+#[tokio::test]
+async fn watch_channel_falls_back_when_ws_unavailable() {
+  let (_child, addr) = start_server().await;
+  let client = BrokenWsClient(reqwest::Client::new());
+  let url = format!("http://localhost:{}", addr.port()).parse().unwrap();
+
+  let metadata_endpoint = denokv_remote::MetadataEndpoint {
+    url,
+    access_token: ACCESS_TOKEN.to_string(),
+  };
+
+  let remote =
+    denokv_remote::Remote::new(client, DummyPermissions, metadata_endpoint);
+
+  set_key(&remote, vec![7], 7).await;
+
+  // The server negotiates v4, every websocket attempt fails, and the watch
+  // must still deliver via the per-watch streaming fallback.
+  let mut watch = remote.watch(vec![vec![7]]);
+  let first = tokio::time::timeout(Duration::from_secs(30), watch.next())
+    .await
+    .expect("no timeout")
+    .unwrap()
+    .expect("watch success");
+  let WatchKeyOutput::Changed { entry: Some(entry) } = &first[0] else {
+    panic!("expected key 7 to have a value: {first:?}");
+  };
+  assert_eq!(entry.key, vec![7]);
+}
+
+#[tokio::test]
+async fn watch_channel_empty_keys_yields_initial_snapshot() {
+  let (_child, addr) = start_server().await;
+  let client = WsReqwestClient(reqwest::Client::new());
+  let url = format!("http://localhost:{}", addr.port()).parse().unwrap();
+
+  let metadata_endpoint = denokv_remote::MetadataEndpoint {
+    url,
+    access_token: ACCESS_TOKEN.to_string(),
+  };
+
+  let remote =
+    denokv_remote::Remote::new(client, DummyPermissions, metadata_endpoint);
+
+  let mut watch = remote.watch(vec![]);
+  let first = tokio::time::timeout(Duration::from_secs(30), watch.next())
+    .await
+    .expect("no timeout")
+    .unwrap()
+    .expect("watch success");
+  assert!(first.is_empty());
+}
+
+#[tokio::test]
+async fn watch_channel_resumes_across_subscriptions() {
+  let (_child, addr) = start_server().await;
+  let client = WsReqwestClient(reqwest::Client::new());
+  let url = format!("http://localhost:{}", addr.port()).parse().unwrap();
+
+  let metadata_endpoint = denokv_remote::MetadataEndpoint {
+    url,
+    access_token: ACCESS_TOKEN.to_string(),
+  };
+
+  let remote =
+    denokv_remote::Remote::new(client, DummyPermissions, metadata_endpoint);
+
+  // Open and fully drain a first watch, then drop it.
+  set_key(&remote, vec![9], 1).await;
+  {
+    let mut watch = remote.watch(vec![vec![9]]);
+    let first = tokio::time::timeout(Duration::from_secs(30), watch.next())
+      .await
+      .expect("no timeout")
+      .unwrap()
+      .expect("watch success");
+    assert!(matches!(
+      &first[0],
+      WatchKeyOutput::Changed { entry: Some(_) }
+    ));
+  }
+
+  // A new watch for the same key must again receive the current state.
+  let mut watch = remote.watch(vec![vec![9]]);
+  let first = tokio::time::timeout(Duration::from_secs(30), watch.next())
+    .await
+    .expect("no timeout")
+    .unwrap()
+    .expect("watch success");
+  let WatchKeyOutput::Changed { entry: Some(entry) } = &first[0] else {
+    panic!("expected key 9 to have a value: {first:?}");
+  };
+  assert!(matches!(entry.value, KvValue::U64(1)));
 }
 
 #[tokio::test]

--- a/proto/kv-connect.md
+++ b/proto/kv-connect.md
@@ -497,6 +497,115 @@ Content-Type: application/octet-stream
 <u32 little endian><protobuf message><u32 little endian><protobuf message>...
 ```
 
+#### Watch Channel (version 4)
+
+A _Watch Channel_ is a long lived WebSocket connection that multiplexes
+watches for many keys over a single connection. Keys can be added to and
+removed from the channel at any time during its lifetime, without opening a
+new connection per watched key set. Servers and clients that negotiated
+protocol version 4 or later during the metadata exchange can use watch
+channels; the _Watch Request_ described above remains available for
+compatibility with older clients and servers.
+
+Like a _Watch Request_, a _Watch Channel_ is always eventually consistent, so
+it MUST be opened against an endpoint that has a `consistency` property that
+is either equal to `strong` or `eventual`.
+
+The client opens a _Watch Channel_ by performing a WebSocket handshake against
+the `<endpointUrl>/watch_channel` endpoint, where `<endpointUrl>` is the
+resolved URL of the selected endpoint with the `http` scheme replaced by `ws`,
+or the `https` scheme replaced by `wss`. The handshake request MUST include
+the same `Authorization`, `x-denokv-version`, and `x-denokv-database-id`
+headers as other _Data Path Protocol_ requests. If authentication fails, the
+server MUST reject the handshake with a 4xx class HTTP status response.
+
+All messages exchanged over the channel are binary WebSocket messages
+containing a single Protobuf encoded message; there is no length prefix, as
+WebSocket message framing already delimits messages. Text messages MUST NOT be
+sent; a peer receiving a text message MUST close the connection.
+
+Each client to server message is in the format
+`com.deno.kv.datapath.WatchChannelClientMessage`. It either adds a key to the
+channel (`add`) or removes one (`remove`):
+
+- `add` starts watching a key. The optional `baseline` describes what the
+  client already knows about the key: the versionstamp of the value it has
+  last seen, or the fact that it has last seen the key as not present. The
+  server MUST send the key's current state if it differs from the baseline,
+  and MUST NOT send it if it matches. When no baseline is given, the server
+  MUST always send the key's current state. Adding a key that is already
+  watched on the channel is permitted and replaces the baseline, re-evaluating
+  it as above; this can be used to fetch the current state of an
+  already-watched key.
+- `remove` stops watching a key. Removing a key that is not watched on the
+  channel has no effect. After the server processes a `remove`, it stops
+  sending updates for that key, but updates already in flight may still be
+  delivered.
+
+Each server to client message is in the format
+`com.deno.kv.datapath.WatchChannelServerMessage`. The `output` message carries
+the new state of one or more watched keys. Unlike `WatchOutput`, only keys
+whose state changed (relative to the baseline, or to the previously delivered
+state) are included; for each such key the message contains the key's current
+value, or no value if the key is not present. The server MAY collapse multiple
+changes to the same key into a single notification, as long as each message
+represents a consistent snapshot of the included keys. Deliveries are
+at-least-once: the server MAY send a state the client has already seen, and
+the client MUST treat each delivery as the key's current state.
+
+The client MUST read the `status` field of each `output` message and verify
+that it is set to `SR_SUCCESS`. If the `status` field is set to
+`SR_READ_DISABLED`, the client SHOULD perform a metadata exchange with the
+server to get a new list of endpoints, and then reconnect. If the `status`
+field is set to any other value, the client MUST fatally abort the channel and
+display an error message to the user.
+
+The server SHOULD send WebSocket Ping frames periodically to keep the
+connection alive and detect dead peers; the client MUST respond with Pong
+frames as required by the WebSocket protocol.
+
+The server MAY enforce a limit on the number of keys concurrently watched on
+one channel. If a client exceeds this limit, the server MUST close the
+connection with WebSocket close code 1008 (policy violation) and a human
+readable reason.
+
+The server MUST NOT retain any watch channel state beyond the lifetime of
+the WebSocket connection: when the connection closes, for any reason, all
+keys watched on it are forgotten. Re-establishment after a disconnect is
+entirely the client's responsibility, and the baseline mechanism makes it
+cheap: if the channel is closed due to a network error, a server restart, or
+an intermediary terminating the connection, the client SHOULD reconnect
+using an exponential backoff strategy and re-add all watched keys, supplying
+the last seen state of each key as the baseline. A server processes such an
+add exactly like any other; baselines merely prevent re-delivery of state
+the client already has. If the channel repeatedly cannot be
+established — for example because an intermediary does not support WebSocket
+upgrades — the client MAY fall back to _Watch Requests_, which remain
+available on servers that support version 4. This makes reconnects lossless and
+free of duplicate deliveries: changes that occurred while disconnected are
+delivered because they differ from the baseline, and unchanged keys are not
+re-delivered.
+
+Example:
+
+```http
+GET /v4/watch_channel HTTP/1.1
+Connection: Upgrade
+Upgrade: websocket
+Sec-WebSocket-Key: <key>
+Sec-WebSocket-Version: 13
+Authorization: Bearer <token>
+x-denokv-version: 4
+x-denokv-database-id: a1b2c3d4-e5f6-7g8h-9i1j-2k3l4m5n6o7p
+```
+
+```http
+HTTP/1.1 101 Switching Protocols
+Connection: Upgrade
+Upgrade: websocket
+Sec-WebSocket-Accept: <accept>
+```
+
 ## Protocol Versions
 
 The KV Connect protocol is versioned. The version of the protocol is negotiated
@@ -542,3 +651,12 @@ Version 3 adds the following features:
 - The `status` field is added to the response body of _Snapshot Read Requests_
   and is used instead of the `read_disabled` boolean field by the client.
 - The "Watch" data path operation is added.
+
+### Version 4
+
+Version 4 adds the following features:
+
+- The "Watch Channel" data path operation is added: a WebSocket endpoint that
+  multiplexes watches for many keys over a single connection, with support for
+  resuming after reconnects without duplicate deliveries. The metadata
+  exchange response format is unchanged from version 3.

--- a/proto/lib.rs
+++ b/proto/lib.rs
@@ -4,6 +4,9 @@ mod codec;
 mod convert;
 mod interface;
 pub mod limits;
+// Re-exported so consumers use the same prost version as the generated
+// message types, regardless of the prost their own workspace pins.
+pub use prost;
 mod protobuf;
 pub mod time;
 pub mod watch_channel_server;

--- a/proto/lib.rs
+++ b/proto/lib.rs
@@ -3,9 +3,10 @@
 mod codec;
 mod convert;
 mod interface;
-mod limits;
+pub mod limits;
 mod protobuf;
 pub mod time;
+pub mod watch_channel_server;
 pub use crate::codec::decode_key;
 pub use crate::codec::encode_key;
 pub use crate::convert::ConvertError;

--- a/proto/protobuf/com.deno.kv.datapath.rs
+++ b/proto/protobuf/com.deno.kv.datapath.rs
@@ -209,6 +209,99 @@ pub struct WatchKeyOutput {
   #[prost(message, optional, tag = "2")]
   pub entry_if_changed: ::core::option::Option<KvEntry>,
 }
+/// A message sent by the client over a watch channel (protocol version 4).
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct WatchChannelClientMessage {
+  #[prost(oneof = "watch_channel_client_message::Message", tags = "1, 2")]
+  pub message: ::core::option::Option<watch_channel_client_message::Message>,
+}
+/// Nested message and enum types in `WatchChannelClientMessage`.
+pub mod watch_channel_client_message {
+  #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+  pub enum Message {
+    /// Start watching a key on this channel.
+    #[prost(message, tag = "1")]
+    Add(super::WatchChannelAdd),
+    /// Stop watching a key on this channel.
+    #[prost(message, tag = "2")]
+    Remove(super::WatchChannelRemove),
+  }
+}
+/// Starts watching a key on a watch channel. Adding a key that is already
+/// watched on the channel is allowed: the server replaces the baseline and
+/// re-evaluates it, so a re-add with a stale baseline causes the current
+/// state to be sent once more.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct WatchChannelAdd {
+  /// The key to watch.
+  #[prost(bytes = "vec", tag = "1")]
+  pub key: ::prost::alloc::vec::Vec<u8>,
+  /// What the client already knows about the key. The server only sends the
+  /// key's current state if it differs from this baseline. When no baseline
+  /// is set the server always sends the current state.
+  #[prost(oneof = "watch_channel_add::Baseline", tags = "2, 3")]
+  pub baseline: ::core::option::Option<watch_channel_add::Baseline>,
+}
+/// Nested message and enum types in `WatchChannelAdd`.
+pub mod watch_channel_add {
+  /// What the client already knows about the key. The server only sends the
+  /// key's current state if it differs from this baseline. When no baseline
+  /// is set the server always sends the current state.
+  #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+  pub enum Baseline {
+    /// The versionstamp of the value the client has last seen.
+    #[prost(bytes, tag = "2")]
+    Versionstamp(::prost::alloc::vec::Vec<u8>),
+    /// Set to true if the client has last seen the key as not present.
+    #[prost(bool, tag = "3")]
+    Absent(bool),
+  }
+}
+/// Stops watching a key on a watch channel.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct WatchChannelRemove {
+  /// The key to stop watching.
+  #[prost(bytes = "vec", tag = "1")]
+  pub key: ::prost::alloc::vec::Vec<u8>,
+}
+/// A message sent by the server over a watch channel (protocol version 4).
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WatchChannelServerMessage {
+  #[prost(oneof = "watch_channel_server_message::Message", tags = "1")]
+  pub message: ::core::option::Option<watch_channel_server_message::Message>,
+}
+/// Nested message and enum types in `WatchChannelServerMessage`.
+pub mod watch_channel_server_message {
+  #[derive(Clone, PartialEq, ::prost::Oneof)]
+  pub enum Message {
+    /// Updates for one or more watched keys.
+    #[prost(message, tag = "1")]
+    Output(super::WatchChannelOutput),
+  }
+}
+/// Updates for watched keys on a watch channel. Unlike WatchOutput, this
+/// message only contains keys whose state differs from what the client is
+/// known to have seen; unchanged keys are not included.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WatchChannelOutput {
+  /// The status of the watch channel.
+  #[prost(enumeration = "SnapshotReadStatus", tag = "1")]
+  pub status: i32,
+  /// The keys that changed.
+  #[prost(message, repeated, tag = "2")]
+  pub keys: ::prost::alloc::vec::Vec<WatchChannelKeyOutput>,
+}
+/// The new state of a single watched key on a watch channel.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct WatchChannelKeyOutput {
+  /// The key that changed.
+  #[prost(bytes = "vec", tag = "1")]
+  pub key: ::prost::alloc::vec::Vec<u8>,
+  /// The key's current value. Not set if the key is not present (it was
+  /// deleted or never existed).
+  #[prost(message, optional, tag = "2")]
+  pub entry: ::core::option::Option<KvEntry>,
+}
 /// The status of a read request.
 #[derive(
   Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration,

--- a/proto/schema/datapath.proto
+++ b/proto/schema/datapath.proto
@@ -227,3 +227,64 @@ message WatchKeyOutput {
   // The new value, if changed is true.
   KvEntry entry_if_changed = 2;
 }
+
+// A message sent by the client over a watch channel (protocol version 4).
+message WatchChannelClientMessage {
+  oneof message {
+    // Start watching a key on this channel.
+    WatchChannelAdd add = 1;
+    // Stop watching a key on this channel.
+    WatchChannelRemove remove = 2;
+  }
+}
+
+// Starts watching a key on a watch channel. Adding a key that is already
+// watched on the channel is allowed: the server replaces the baseline and
+// re-evaluates it, so a re-add with a stale baseline causes the current
+// state to be sent once more.
+message WatchChannelAdd {
+  // The key to watch.
+  bytes key = 1;
+  // What the client already knows about the key. The server only sends the
+  // key's current state if it differs from this baseline. When no baseline
+  // is set the server always sends the current state.
+  oneof baseline {
+    // The versionstamp of the value the client has last seen.
+    bytes versionstamp = 2;
+    // Set to true if the client has last seen the key as not present.
+    bool absent = 3;
+  }
+}
+
+// Stops watching a key on a watch channel.
+message WatchChannelRemove {
+  // The key to stop watching.
+  bytes key = 1;
+}
+
+// A message sent by the server over a watch channel (protocol version 4).
+message WatchChannelServerMessage {
+  oneof message {
+    // Updates for one or more watched keys.
+    WatchChannelOutput output = 1;
+  }
+}
+
+// Updates for watched keys on a watch channel. Unlike WatchOutput, this
+// message only contains keys whose state differs from what the client is
+// known to have seen; unchanged keys are not included.
+message WatchChannelOutput {
+  // The status of the watch channel.
+  SnapshotReadStatus status = 1;
+  // The keys that changed.
+  repeated WatchChannelKeyOutput keys = 2;
+}
+
+// The new state of a single watched key on a watch channel.
+message WatchChannelKeyOutput {
+  // The key that changed.
+  bytes key = 1;
+  // The key's current value. Not set if the key is not present (it was
+  // deleted or never existed).
+  KvEntry entry = 2;
+}

--- a/proto/watch_channel_server.rs
+++ b/proto/watch_channel_server.rs
@@ -31,8 +31,9 @@ enum KnownState {
 /// The effect of one client message on the channel.
 #[derive(Debug, PartialEq)]
 pub enum ClientMessageEffect {
-  /// The watched key set changed; the backend watcher must be updated.
-  KeysChanged,
+  /// A key was added (or re-added); the backend watcher must be updated
+  /// and the key's current state must be (re-)evaluated.
+  KeyAdded(Vec<u8>),
   /// No change to the watched key set.
   None,
   /// The message violates the protocol; the connection must be closed
@@ -52,7 +53,9 @@ impl WatchChannelServer {
     Self {
       known: BTreeMap::new(),
       max_keys,
-      max_key_size: crate::limits::MAX_READ_KEY_SIZE_BYTES,
+      // Watchable keys are writable keys; this also keeps successor-key
+      // range reads (key + 0x00) within MAX_READ_KEY_SIZE_BYTES.
+      max_key_size: crate::limits::MAX_WRITE_KEY_SIZE_BYTES,
     }
   }
 
@@ -80,8 +83,8 @@ impl WatchChannelServer {
           }
           _ => KnownState::Unknown,
         };
-        self.known.insert(add.key, baseline);
-        ClientMessageEffect::KeysChanged
+        self.known.insert(add.key.clone(), baseline);
+        ClientMessageEffect::KeyAdded(add.key)
       }
       Some(pb::watch_channel_client_message::Message::Remove(remove)) => {
         // The key set shrank, but the backend watcher does not need to be
@@ -211,7 +214,7 @@ mod tests {
     let mut server = WatchChannelServer::new(16);
     assert_eq!(
       server.apply_client_message(&add(b"a", None)),
-      ClientMessageEffect::KeysChanged
+      ClientMessageEffect::KeyAdded(b"a".to_vec())
     );
     // Present key.
     let message = server
@@ -307,9 +310,9 @@ mod tests {
     // Re-adding an existing key is not a cap violation.
     assert_eq!(
       server.apply_client_message(&add(b"a", None)),
-      ClientMessageEffect::KeysChanged
+      ClientMessageEffect::KeyAdded(b"a".to_vec())
     );
-    let huge = vec![0u8; crate::limits::MAX_READ_KEY_SIZE_BYTES + 1];
+    let huge = vec![0u8; crate::limits::MAX_WRITE_KEY_SIZE_BYTES + 1];
     assert_eq!(
       server.apply_client_message(&add(&huge, None)),
       ClientMessageEffect::Reject("key too large")

--- a/proto/watch_channel_server.rs
+++ b/proto/watch_channel_server.rs
@@ -1,0 +1,327 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+
+//! Server-side state machine for the KV Connect watch channel (protocol
+//! version 4). See `kv-connect.md`, "Watch Channel (version 4)".
+//!
+//! The state machine is transport- and backend-agnostic: it decodes client
+//! messages, tracks what the connected client is known to have seen per
+//! key, and diffs backend-observed key states against that knowledge so
+//! only genuinely new state is sent. The caller owns the WebSocket and the
+//! backend watcher; this type owns nothing but per-connection bookkeeping,
+//! and is discarded with the connection (the server keeps no watch state
+//! across connections).
+
+use std::collections::BTreeMap;
+
+use prost::Message;
+
+use crate::datapath as pb;
+
+/// What the connected client is known to have last seen for a key.
+#[derive(Clone, PartialEq)]
+enum KnownState {
+  /// Nothing delivered yet (and no baseline supplied).
+  Unknown,
+  /// Last seen as not present.
+  Absent,
+  /// Last seen with this versionstamp.
+  Versionstamp(Vec<u8>),
+}
+
+/// The effect of one client message on the channel.
+#[derive(Debug, PartialEq)]
+pub enum ClientMessageEffect {
+  /// The watched key set changed; the backend watcher must be updated.
+  KeysChanged,
+  /// No change to the watched key set.
+  None,
+  /// The message violates the protocol; the connection must be closed
+  /// (WebSocket close code 1008) with this reason.
+  Reject(&'static str),
+}
+
+/// Per-connection watch channel state.
+pub struct WatchChannelServer {
+  known: BTreeMap<Vec<u8>, KnownState>,
+  max_keys: usize,
+  max_key_size: usize,
+}
+
+impl WatchChannelServer {
+  pub fn new(max_keys: usize) -> Self {
+    Self {
+      known: BTreeMap::new(),
+      max_keys,
+      max_key_size: crate::limits::MAX_READ_KEY_SIZE_BYTES,
+    }
+  }
+
+  /// Apply one binary client message (a `WatchChannelClientMessage`).
+  pub fn apply_client_message(&mut self, bytes: &[u8]) -> ClientMessageEffect {
+    let Ok(message) = pb::WatchChannelClientMessage::decode(bytes) else {
+      return ClientMessageEffect::Reject("invalid message");
+    };
+    match message.message {
+      Some(pb::watch_channel_client_message::Message::Add(add)) => {
+        if add.key.len() > self.max_key_size {
+          return ClientMessageEffect::Reject("key too large");
+        }
+        if !self.known.contains_key(&add.key)
+          && self.known.len() >= self.max_keys
+        {
+          return ClientMessageEffect::Reject("too many watched keys");
+        }
+        let baseline = match add.baseline {
+          Some(pb::watch_channel_add::Baseline::Versionstamp(v)) => {
+            KnownState::Versionstamp(v)
+          }
+          Some(pb::watch_channel_add::Baseline::Absent(true)) => {
+            KnownState::Absent
+          }
+          _ => KnownState::Unknown,
+        };
+        self.known.insert(add.key, baseline);
+        ClientMessageEffect::KeysChanged
+      }
+      Some(pb::watch_channel_client_message::Message::Remove(remove)) => {
+        // The key set shrank, but the backend watcher does not need to be
+        // updated for correctness: `diff` ignores keys that are no longer
+        // watched.
+        self.known.remove(&remove.key);
+        ClientMessageEffect::None
+      }
+      // A message from a newer protocol revision; ignore.
+      None => ClientMessageEffect::None,
+    }
+  }
+
+  /// The currently watched keys, in sorted order.
+  pub fn watched_keys(&self) -> Vec<Vec<u8>> {
+    self.known.keys().cloned().collect()
+  }
+
+  pub fn key_count(&self) -> usize {
+    self.known.len()
+  }
+
+  /// Diff observed key states against what the client has seen and return
+  /// the encoded `WatchChannelServerMessage` to send, if anything changed.
+  /// `states` items are (key, current entry; `None` = key not present).
+  /// Keys that are not (or no longer) watched are ignored.
+  pub fn diff(
+    &mut self,
+    states: impl IntoIterator<Item = (Vec<u8>, Option<pb::KvEntry>)>,
+  ) -> Option<Vec<u8>> {
+    let mut changed = Vec::new();
+    for (key, entry) in states {
+      let Some(state) = self.known.get_mut(&key) else {
+        continue;
+      };
+      let new_state = match &entry {
+        Some(entry) => KnownState::Versionstamp(entry.versionstamp.clone()),
+        None => KnownState::Absent,
+      };
+      if *state == new_state {
+        continue;
+      }
+      *state = new_state;
+      changed.push(pb::WatchChannelKeyOutput { key, entry });
+    }
+    if changed.is_empty() {
+      return None;
+    }
+    let message = pb::WatchChannelServerMessage {
+      message: Some(pb::watch_channel_server_message::Message::Output(
+        pb::WatchChannelOutput {
+          status: pb::SnapshotReadStatus::SrSuccess as i32,
+          keys: changed,
+        },
+      )),
+    };
+    Some(message.encode_to_vec())
+  }
+
+  /// Encode a server message that carries only a status (no key outputs),
+  /// e.g. to tell the client that reads are disabled and it should refresh
+  /// its metadata. Provided here so servers do not need a matching prost
+  /// version to construct protocol messages.
+  pub fn encode_status_only_message(status: i32) -> Vec<u8> {
+    pb::WatchChannelServerMessage {
+      message: Some(pb::watch_channel_server_message::Message::Output(
+        pb::WatchChannelOutput {
+          status,
+          keys: Vec::new(),
+        },
+      )),
+    }
+    .encode_to_vec()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn add(
+    key: &[u8],
+    baseline: Option<pb::watch_channel_add::Baseline>,
+  ) -> Vec<u8> {
+    pb::WatchChannelClientMessage {
+      message: Some(pb::watch_channel_client_message::Message::Add(
+        pb::WatchChannelAdd {
+          key: key.to_vec(),
+          baseline,
+        },
+      )),
+    }
+    .encode_to_vec()
+  }
+
+  fn remove(key: &[u8]) -> Vec<u8> {
+    pb::WatchChannelClientMessage {
+      message: Some(pb::watch_channel_client_message::Message::Remove(
+        pb::WatchChannelRemove { key: key.to_vec() },
+      )),
+    }
+    .encode_to_vec()
+  }
+
+  fn entry(versionstamp: &[u8]) -> pb::KvEntry {
+    pb::KvEntry {
+      key: b"k".to_vec(),
+      value: b"v".to_vec(),
+      encoding: 0,
+      versionstamp: versionstamp.to_vec(),
+    }
+  }
+
+  fn decoded_keys(message: &[u8]) -> Vec<(Vec<u8>, Option<pb::KvEntry>)> {
+    let message = pb::WatchChannelServerMessage::decode(message).unwrap();
+    let Some(pb::watch_channel_server_message::Message::Output(output)) =
+      message.message
+    else {
+      panic!("expected output message");
+    };
+    assert_eq!(output.status, pb::SnapshotReadStatus::SrSuccess as i32);
+    output.keys.into_iter().map(|k| (k.key, k.entry)).collect()
+  }
+
+  #[test]
+  fn add_without_baseline_sends_current_state() {
+    let mut server = WatchChannelServer::new(16);
+    assert_eq!(
+      server.apply_client_message(&add(b"a", None)),
+      ClientMessageEffect::KeysChanged
+    );
+    // Present key.
+    let message = server
+      .diff(vec![(b"a".to_vec(), Some(entry(b"v1")))])
+      .expect("state must be sent");
+    assert_eq!(decoded_keys(&message).len(), 1);
+    // Re-observing the same state sends nothing.
+    assert!(server
+      .diff(vec![(b"a".to_vec(), Some(entry(b"v1")))])
+      .is_none());
+  }
+
+  #[test]
+  fn add_without_baseline_reports_absent_keys() {
+    let mut server = WatchChannelServer::new(16);
+    server.apply_client_message(&add(b"a", None));
+    let message = server
+      .diff(vec![(b"a".to_vec(), None)])
+      .expect("absence must be reported");
+    let keys = decoded_keys(&message);
+    assert_eq!(keys[0].0, b"a".to_vec());
+    assert!(keys[0].1.is_none());
+    assert!(server.diff(vec![(b"a".to_vec(), None)]).is_none());
+  }
+
+  #[test]
+  fn matching_baseline_suppresses_initial_state() {
+    let mut server = WatchChannelServer::new(16);
+    server.apply_client_message(&add(
+      b"a",
+      Some(pb::watch_channel_add::Baseline::Versionstamp(
+        b"v1".to_vec(),
+      )),
+    ));
+    assert!(server
+      .diff(vec![(b"a".to_vec(), Some(entry(b"v1")))])
+      .is_none());
+    // A different versionstamp is sent.
+    assert!(server
+      .diff(vec![(b"a".to_vec(), Some(entry(b"v2")))])
+      .is_some());
+  }
+
+  #[test]
+  fn absent_baseline_suppresses_absence() {
+    let mut server = WatchChannelServer::new(16);
+    server.apply_client_message(&add(
+      b"a",
+      Some(pb::watch_channel_add::Baseline::Absent(true)),
+    ));
+    assert!(server.diff(vec![(b"a".to_vec(), None)]).is_none());
+    assert!(server
+      .diff(vec![(b"a".to_vec(), Some(entry(b"v1")))])
+      .is_some());
+  }
+
+  #[test]
+  fn re_add_resets_the_baseline() {
+    let mut server = WatchChannelServer::new(16);
+    server.apply_client_message(&add(b"a", None));
+    assert!(server
+      .diff(vec![(b"a".to_vec(), Some(entry(b"v1")))])
+      .is_some());
+    // Re-add without baseline: current state must be re-sent.
+    server.apply_client_message(&add(b"a", None));
+    assert!(server
+      .diff(vec![(b"a".to_vec(), Some(entry(b"v1")))])
+      .is_some());
+  }
+
+  #[test]
+  fn removed_keys_are_ignored() {
+    let mut server = WatchChannelServer::new(16);
+    server.apply_client_message(&add(b"a", None));
+    assert_eq!(
+      server.apply_client_message(&remove(b"a")),
+      ClientMessageEffect::None
+    );
+    assert!(server
+      .diff(vec![(b"a".to_vec(), Some(entry(b"v1")))])
+      .is_none());
+    assert_eq!(server.key_count(), 0);
+  }
+
+  #[test]
+  fn key_cap_and_key_size_are_enforced() {
+    let mut server = WatchChannelServer::new(1);
+    server.apply_client_message(&add(b"a", None));
+    assert_eq!(
+      server.apply_client_message(&add(b"b", None)),
+      ClientMessageEffect::Reject("too many watched keys")
+    );
+    // Re-adding an existing key is not a cap violation.
+    assert_eq!(
+      server.apply_client_message(&add(b"a", None)),
+      ClientMessageEffect::KeysChanged
+    );
+    let huge = vec![0u8; crate::limits::MAX_READ_KEY_SIZE_BYTES + 1];
+    assert_eq!(
+      server.apply_client_message(&add(&huge, None)),
+      ClientMessageEffect::Reject("key too large")
+    );
+  }
+
+  #[test]
+  fn garbage_is_rejected() {
+    let mut server = WatchChannelServer::new(16);
+    assert_eq!(
+      server.apply_client_message(b"\xff\xff\xff"),
+      ClientMessageEffect::Reject("invalid message")
+    );
+  }
+}

--- a/remote/lib.rs
+++ b/remote/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 
 mod time;
+mod watch_channel;
 
 use std::io;
 use std::ops::Sub;
@@ -31,6 +32,7 @@ use denokv_proto::ReadRangeOutput;
 use denokv_proto::SnapshotReadOptions;
 use denokv_proto::WatchKeyOutput;
 use futures::Future;
+use futures::Sink;
 use futures::Stream;
 use futures::StreamExt;
 use futures::TryStreamExt;
@@ -83,6 +85,7 @@ enum ProtocolVersion {
   V1,
   V2,
   V3,
+  V4,
 }
 
 #[derive(PartialEq, Eq)]
@@ -136,6 +139,13 @@ impl Metadata {
         );
         headers.insert("x-denokv-version", HeaderValue::from_static("3"));
       }
+      ProtocolVersion::V4 => {
+        headers.insert(
+          "x-denokv-database-id",
+          self.database_id.to_string().try_into().unwrap(),
+        );
+        headers.insert("x-denokv-version", HeaderValue::from_static("4"));
+      }
     };
     headers
   }
@@ -167,7 +177,43 @@ pub trait RemoteTransport: Clone + Send + Sync + 'static {
     Output = Result<(Url, http::StatusCode, Self::Response), JsErrorBox>,
   > + Send
        + Sync;
+
+  /// Whether this transport can open WebSocket connections. Transports that
+  /// return false never advertise protocol version 4 during the metadata
+  /// exchange, so [`RemoteTransport::websocket`] is never called on them.
+  fn supports_watch_channel(&self) -> bool {
+    false
+  }
+
+  /// Open a WebSocket connection to the given `ws`/`wss` URL, sending the
+  /// given headers with the handshake request. The returned sink and stream
+  /// carry binary WebSocket messages; the transport is responsible for
+  /// answering ping frames.
+  fn websocket(
+    &self,
+    url: Url,
+    headers: http::HeaderMap,
+  ) -> impl Future<
+    Output = Result<(WebSocketMessageSink, WebSocketMessageStream), JsErrorBox>,
+  > + Send {
+    let _ = (url, headers);
+    async {
+      Err(JsErrorBox::generic(
+        "this transport does not support websockets",
+      ))
+    }
+  }
 }
+
+/// The sending half of a WebSocket connection opened by a
+/// [`RemoteTransport`]. Each item is one binary WebSocket message.
+pub type WebSocketMessageSink =
+  Pin<Box<dyn Sink<Bytes, Error = JsErrorBox> + Send>>;
+/// The receiving half of a WebSocket connection opened by a
+/// [`RemoteTransport`]. Each item is one binary WebSocket message; control
+/// frames (ping/pong/close) are handled by the transport and not surfaced.
+pub type WebSocketMessageStream =
+  Pin<Box<dyn Stream<Item = Result<Bytes, JsErrorBox>> + Send>>;
 
 /// A response object.
 pub trait RemoteResponse: Send + Sync {
@@ -250,6 +296,8 @@ pub struct Remote<P: RemotePermissions, T: RemoteTransport> {
   client: T,
   metadata_refresher: Arc<MetadataRefresher>,
   metadata: watch::Receiver<MetadataState>,
+  watch_channel:
+    Arc<std::sync::OnceLock<Arc<watch_channel::WatchChannelManager>>>,
 }
 
 impl<P: RemotePermissions, T: RemoteTransport> Remote<P, T> {
@@ -274,6 +322,40 @@ impl<P: RemotePermissions, T: RemoteTransport> Remote<P, T> {
         handle,
       }),
       metadata: rx,
+      watch_channel: Arc::new(std::sync::OnceLock::new()),
+    }
+  }
+
+  /// The shared watch channel manager for this database, created on first
+  /// use. Only used when protocol version 4 was negotiated.
+  fn watch_channel_manager(&self) -> Arc<watch_channel::WatchChannelManager> {
+    self
+      .watch_channel
+      .get_or_init(|| {
+        Arc::new(watch_channel::WatchChannelManager::new(
+          self.client.clone(),
+          self.metadata.clone(),
+          self.metadata_refresher.refresh_now.clone(),
+        ))
+      })
+      .clone()
+  }
+
+  /// Wait until the metadata exchange has completed and return the
+  /// resulting metadata snapshot.
+  async fn wait_metadata(&self) -> Result<Arc<Metadata>, JsErrorBox> {
+    let mut metadata_rx = self.metadata.clone();
+    loop {
+      match &*metadata_rx.borrow_and_update() {
+        MetadataState::Pending => {}
+        MetadataState::Ok(metadata) => return Ok(metadata.clone()),
+        MetadataState::Error(e) => {
+          return Err(JsErrorBox::from_err(CallRawError::Other(e.to_string())))
+        }
+      }
+      if metadata_rx.changed().await.is_err() {
+        return Err(JsErrorBox::from_err(CallRawError::DatabaseClosed));
+      }
     }
   }
 
@@ -546,10 +628,13 @@ async fn fetch_metadata<T: RemoteTransport>(
   client: &T,
   metadata_endpoint: &MetadataEndpoint,
 ) -> RetryableResult<Metadata, String> {
-  let body = serde_json::to_vec(&MetadataExchangeRequest {
-    supported_versions: vec![1, 2, 3],
-  })
-  .unwrap();
+  let mut supported_versions = vec![1, 2, 3];
+  if client.supports_watch_channel() {
+    supported_versions.push(4);
+  }
+  let body =
+    serde_json::to_vec(&MetadataExchangeRequest { supported_versions })
+      .unwrap();
   let res = match client
     .post(
       metadata_endpoint.url.clone(),
@@ -627,12 +712,13 @@ fn parse_metadata(base_url: &Url, body: &str) -> Result<Metadata, String> {
     1 => ProtocolVersion::V1,
     2 => ProtocolVersion::V2,
     3 => ProtocolVersion::V3,
+    4 => ProtocolVersion::V4,
     version => {
       return Err(format!("unsupported metadata version: {version}"));
     }
   };
 
-  // V1, V2, and V3 have the same shape
+  // V1 through V4 have the same shape
   let metadata: DatabaseMetadata = match serde_json::from_str(body) {
     Ok(metadata) => metadata,
     Err(err) => {
@@ -644,7 +730,7 @@ fn parse_metadata(base_url: &Url, body: &str) -> Result<Metadata, String> {
   for endpoint in metadata.endpoints {
     let url = match version {
       ProtocolVersion::V1 => Url::parse(&endpoint.url),
-      ProtocolVersion::V2 | ProtocolVersion::V3 => {
+      ProtocolVersion::V2 | ProtocolVersion::V3 | ProtocolVersion::V4 => {
         Url::options().base_url(Some(base_url)).parse(&endpoint.url)
       }
     }
@@ -766,7 +852,7 @@ impl<P: RemotePermissions, T: RemoteTransport> Database for Remote<P, T> {
           return Err(JsErrorBox::from_err(SnapshotReadError::ReadsDisabled));
         }
       }
-      ProtocolVersion::V3 => match res.status() {
+      ProtocolVersion::V3 | ProtocolVersion::V4 => match res.status() {
         pb::SnapshotReadStatus::SrSuccess => {}
         pb::SnapshotReadStatus::SrReadDisabled => {
           // TODO: this should result in a retry after a forced metadata refresh.
@@ -957,6 +1043,72 @@ impl<P: RemotePermissions, T: RemoteTransport> Database for Remote<P, T> {
   ) -> Pin<Box<dyn Stream<Item = Result<Vec<WatchKeyOutput>, JsErrorBox>>>> {
     let this = self.clone();
     let stream = try_stream! {
+      // Protocol version 4 multiplexes all watches for this database over
+      // one WebSocket channel; older versions open one streaming request
+      // per watch call. The channel is only used when it can mirror the
+      // version 3 behavior exactly: when the channel turns out to be
+      // unusable (e.g. an intermediary blocks WebSockets), the code falls
+      // through to the per-watch streaming path below.
+      let mut use_channel = this.client.supports_watch_channel()
+        && keys.len() <= denokv_proto::limits::MAX_WATCHED_KEYS;
+      if use_channel {
+        let metadata = this.wait_metadata().await?;
+        use_channel = metadata.version == ProtocolVersion::V4;
+        if use_channel && keys.is_empty() {
+          // Version 3 answers an empty watch with one empty initial
+          // snapshot and then nothing but keepalives; mirror that without
+          // occupying the channel.
+          yield Vec::new();
+          std::future::pending::<()>().await;
+        }
+        if use_channel {
+          // Permission checks happen here, against the endpoints in the
+          // current metadata; the channel driver records them and refuses
+          // endpoints that were never checked (it cannot check itself
+          // because permissions are not required to be thread safe).
+          let manager = this.watch_channel_manager();
+          let mut approved = Vec::with_capacity(metadata.endpoints.len());
+          for endpoint in &metadata.endpoints {
+            let url = Url::parse(&format!("{}/watch_channel", endpoint.url))
+              .map_err(|e| JsErrorBox::generic(e.to_string()))?;
+            this
+              .permissions
+              .check_net_url(&url)
+              .map_err(CallRawError::Permission)
+              .map_err(JsErrorBox::from_err)?;
+            approved.push(url.to_string());
+          }
+          manager.approve_endpoints(approved);
+
+          let subscription = manager.subscribe(keys.clone());
+          let mut subscription = pin!(subscription);
+          let mut fall_back = false;
+          while let Some(outputs) = subscription.next().await {
+            match outputs {
+              Ok(outputs) => yield outputs,
+              Err(error)
+                if error
+                  .to_string()
+                  .starts_with(watch_channel::CHANNEL_UNAVAILABLE_PREFIX) =>
+              {
+                warn!(
+                  "KV Connect falling back to per-watch streaming: {error}"
+                );
+                fall_back = true;
+                break;
+              }
+              Err(error) => {
+                Err(error)?;
+              }
+            }
+          }
+          if !fall_back {
+            // The manager (and the database) was dropped.
+            return;
+          }
+        }
+      }
+
       let mut attempt = 0;
        loop {
         attempt += 1;
@@ -1007,19 +1159,8 @@ impl<P: RemotePermissions, T: RemoteTransport> Database for Remote<P, T> {
             if !key.changed {
               outputs.push(WatchKeyOutput::Unchanged);
             } else {
-              let entry = match key.entry_if_changed {
-                Some(entry) => {
-                  let value = decode_value(entry.value, entry.encoding as i64)
-                    .ok_or_else(|| JsErrorBox::from_err(WatchError::UnknownEncoding(entry.encoding)))?;
-                  Some(KvEntry {
-                    key: entry.key,
-                    value,
-                    versionstamp: <[u8; 10]>::try_from(&entry.versionstamp[..]).map_err(|e| JsErrorBox::from_err(WatchError::TryFromSlice(e)))?,
-                  })
-                },
-                None => None,
-              };
-              outputs.push(WatchKeyOutput::Changed { entry });
+              outputs
+                .push(watch_channel::convert_entry(key.entry_if_changed.as_ref())?);
             }
           }
           yield outputs;

--- a/remote/lib.rs
+++ b/remote/lib.rs
@@ -372,6 +372,147 @@ impl<P: RemotePermissions, T: RemoteTransport> Remote<P, T> {
       tokio::time::timeout(FORCED_REFRESH_WAIT, metadata_rx.changed()).await;
   }
 
+  /// The shared implementation behind [`Database::watch`] and
+  /// [`Remote::watch`]. The returned opaque stream is `Send` exactly when
+  /// `P` and `T` are (auto-trait leakage), which the public wrappers rely
+  /// on.
+  fn watch_stream(
+    &self,
+    keys: Vec<Vec<u8>>,
+  ) -> impl Stream<Item = Result<Vec<WatchKeyOutput>, JsErrorBox>> + use<P, T>
+  {
+    let this = self.clone();
+    let stream = try_stream! {
+      // Protocol version 4 multiplexes all watches for this database over
+      // one WebSocket channel; older versions open one streaming request
+      // per watch call. The channel is only used when it can mirror the
+      // version 3 behavior exactly: when the channel turns out to be
+      // unusable (e.g. an intermediary blocks WebSockets), the code falls
+      // through to the per-watch streaming path below.
+      let mut use_channel = this.client.supports_watch_channel()
+        && keys.len() <= denokv_proto::limits::MAX_WATCHED_KEYS;
+      if use_channel {
+        let metadata = this.wait_metadata().await?;
+        use_channel = metadata.version == ProtocolVersion::V4;
+        if use_channel && keys.is_empty() {
+          // Version 3 answers an empty watch with one empty initial
+          // snapshot and then nothing but keepalives; mirror that without
+          // occupying the channel.
+          yield Vec::new();
+          std::future::pending::<()>().await;
+        }
+        if use_channel {
+          // Permission checks happen here, against the endpoints in the
+          // current metadata; the channel driver records them and refuses
+          // endpoints that were never checked (it cannot check itself
+          // because permissions are not required to be thread safe).
+          let manager = this.watch_channel_manager();
+          let mut approved = Vec::with_capacity(metadata.endpoints.len());
+          for endpoint in &metadata.endpoints {
+            let url = Url::parse(&format!("{}/watch_channel", endpoint.url))
+              .map_err(|e| JsErrorBox::generic(e.to_string()))?;
+            this
+              .permissions
+              .check_net_url(&url)
+              .map_err(CallRawError::Permission)
+              .map_err(JsErrorBox::from_err)?;
+            approved.push(url.to_string());
+          }
+          manager.approve_endpoints(approved);
+
+          let subscription = manager.subscribe(keys.clone());
+          let mut subscription = pin!(subscription);
+          let mut fall_back = false;
+          while let Some(outputs) = subscription.next().await {
+            match outputs {
+              Ok(outputs) => yield outputs,
+              Err(error)
+                if error
+                  .to_string()
+                  .starts_with(watch_channel::CHANNEL_UNAVAILABLE_PREFIX) =>
+              {
+                warn!(
+                  "KV Connect falling back to per-watch streaming: {error}"
+                );
+                fall_back = true;
+                break;
+              }
+              Err(error) => {
+                Err(error)?;
+              }
+            }
+          }
+          if !fall_back {
+            // The manager (and the database) was dropped.
+            return;
+          }
+        }
+      }
+
+      let mut attempt = 0;
+       loop {
+        attempt += 1;
+        let req = pb::Watch {
+          keys: keys.iter().map(|key| pb::WatchKey { key: key.clone() }).collect(),
+        };
+
+        let (stream, _) = this.call_stream("watch", req).await?;
+        let stream = pin!(stream);
+        let reader = StreamReader::new(stream);
+        let codec = LengthDelimitedCodec::builder()
+          .little_endian()
+          .length_field_length(4)
+          .max_frame_length(16 * 1048576)
+          .new_codec();
+
+        let mut frames = tokio_util::codec::FramedRead::new(reader, codec);
+        'decode: loop {
+          let res = frames.next().await;
+          let frame = match res {
+            Some(Ok(frame)) if frame.is_empty() => continue, // ping, ignore
+            Some(Ok(frame)) => frame,
+            Some(Err(err)) => {
+              debug!("KV Connect watch disconnected (attempt={}): {}", attempt, err);
+              break 'decode;
+            }
+            None => {
+              break 'decode;
+            }
+          };
+
+          let data = pb::WatchOutput::decode(frame).map_err(|e: prost::DecodeError| JsErrorBox::from_err(WatchError::Decode(e)))?;
+          match data.status() {
+            pb::SnapshotReadStatus::SrSuccess => {}
+            pb::SnapshotReadStatus::SrReadDisabled => {
+              // TODO: this should result in a retry after a forced metadata refresh.
+              Err(JsErrorBox::from_err(WatchError::ReadsDisabled))?;
+              unreachable!();
+            }
+            pb::SnapshotReadStatus::SrUnspecified => {
+              Err(JsErrorBox::from_err(WatchError::UnspecifiedRead(data.status)))?;
+              unreachable!();
+            }
+          }
+
+          let mut outputs = Vec::new();
+          for key in data.keys {
+            if !key.changed {
+              outputs.push(WatchKeyOutput::Unchanged);
+            } else {
+              outputs
+                .push(watch_channel::convert_entry(key.entry_if_changed.as_ref())?);
+            }
+          }
+          yield outputs;
+        }
+
+        // The stream disconnected, so retry after a short delay.
+        randomized_exponential_backoff(DATAPATH_BACKOFF_BASE, attempt).await;
+      }
+    };
+    stream
+  }
+
   async fn call_raw<Req: prost::Message>(
     &self,
     method: &'static str,
@@ -530,6 +671,19 @@ impl<P: RemotePermissions, T: RemoteTransport> Remote<P, T> {
     let resp = Resp::decode(resp_body).map_err(CallDataError::Decode)?;
 
     Ok((resp, version))
+  }
+}
+
+impl<P: RemotePermissions + Send + Sync, T: RemoteTransport> Remote<P, T> {
+  /// Watch keys for changes. Identical to [`Database::watch`], but the
+  /// returned stream is `Send`. (The `Database` trait's stream type is not
+  /// `Send`, for the benefit of single-threaded embedders.)
+  pub fn watch(
+    &self,
+    keys: Vec<Vec<u8>>,
+  ) -> Pin<Box<dyn Stream<Item = Result<Vec<WatchKeyOutput>, JsErrorBox>> + Send>>
+  {
+    Box::pin(self.watch_stream(keys))
   }
 }
 
@@ -1041,136 +1195,7 @@ impl<P: RemotePermissions, T: RemoteTransport> Database for Remote<P, T> {
     &self,
     keys: Vec<Vec<u8>>,
   ) -> Pin<Box<dyn Stream<Item = Result<Vec<WatchKeyOutput>, JsErrorBox>>>> {
-    let this = self.clone();
-    let stream = try_stream! {
-      // Protocol version 4 multiplexes all watches for this database over
-      // one WebSocket channel; older versions open one streaming request
-      // per watch call. The channel is only used when it can mirror the
-      // version 3 behavior exactly: when the channel turns out to be
-      // unusable (e.g. an intermediary blocks WebSockets), the code falls
-      // through to the per-watch streaming path below.
-      let mut use_channel = this.client.supports_watch_channel()
-        && keys.len() <= denokv_proto::limits::MAX_WATCHED_KEYS;
-      if use_channel {
-        let metadata = this.wait_metadata().await?;
-        use_channel = metadata.version == ProtocolVersion::V4;
-        if use_channel && keys.is_empty() {
-          // Version 3 answers an empty watch with one empty initial
-          // snapshot and then nothing but keepalives; mirror that without
-          // occupying the channel.
-          yield Vec::new();
-          std::future::pending::<()>().await;
-        }
-        if use_channel {
-          // Permission checks happen here, against the endpoints in the
-          // current metadata; the channel driver records them and refuses
-          // endpoints that were never checked (it cannot check itself
-          // because permissions are not required to be thread safe).
-          let manager = this.watch_channel_manager();
-          let mut approved = Vec::with_capacity(metadata.endpoints.len());
-          for endpoint in &metadata.endpoints {
-            let url = Url::parse(&format!("{}/watch_channel", endpoint.url))
-              .map_err(|e| JsErrorBox::generic(e.to_string()))?;
-            this
-              .permissions
-              .check_net_url(&url)
-              .map_err(CallRawError::Permission)
-              .map_err(JsErrorBox::from_err)?;
-            approved.push(url.to_string());
-          }
-          manager.approve_endpoints(approved);
-
-          let subscription = manager.subscribe(keys.clone());
-          let mut subscription = pin!(subscription);
-          let mut fall_back = false;
-          while let Some(outputs) = subscription.next().await {
-            match outputs {
-              Ok(outputs) => yield outputs,
-              Err(error)
-                if error
-                  .to_string()
-                  .starts_with(watch_channel::CHANNEL_UNAVAILABLE_PREFIX) =>
-              {
-                warn!(
-                  "KV Connect falling back to per-watch streaming: {error}"
-                );
-                fall_back = true;
-                break;
-              }
-              Err(error) => {
-                Err(error)?;
-              }
-            }
-          }
-          if !fall_back {
-            // The manager (and the database) was dropped.
-            return;
-          }
-        }
-      }
-
-      let mut attempt = 0;
-       loop {
-        attempt += 1;
-        let req = pb::Watch {
-          keys: keys.iter().map(|key| pb::WatchKey { key: key.clone() }).collect(),
-        };
-
-        let (stream, _) = this.call_stream("watch", req).await?;
-        let stream = pin!(stream);
-        let reader = StreamReader::new(stream);
-        let codec = LengthDelimitedCodec::builder()
-          .little_endian()
-          .length_field_length(4)
-          .max_frame_length(16 * 1048576)
-          .new_codec();
-
-        let mut frames = tokio_util::codec::FramedRead::new(reader, codec);
-        'decode: loop {
-          let res = frames.next().await;
-          let frame = match res {
-            Some(Ok(frame)) if frame.is_empty() => continue, // ping, ignore
-            Some(Ok(frame)) => frame,
-            Some(Err(err)) => {
-              debug!("KV Connect watch disconnected (attempt={}): {}", attempt, err);
-              break 'decode;
-            }
-            None => {
-              break 'decode;
-            }
-          };
-
-          let data = pb::WatchOutput::decode(frame).map_err(|e: prost::DecodeError| JsErrorBox::from_err(WatchError::Decode(e)))?;
-          match data.status() {
-            pb::SnapshotReadStatus::SrSuccess => {}
-            pb::SnapshotReadStatus::SrReadDisabled => {
-              // TODO: this should result in a retry after a forced metadata refresh.
-              Err(JsErrorBox::from_err(WatchError::ReadsDisabled))?;
-              unreachable!();
-            }
-            pb::SnapshotReadStatus::SrUnspecified => {
-              Err(JsErrorBox::from_err(WatchError::UnspecifiedRead(data.status)))?;
-              unreachable!();
-            }
-          }
-
-          let mut outputs = Vec::new();
-          for key in data.keys {
-            if !key.changed {
-              outputs.push(WatchKeyOutput::Unchanged);
-            } else {
-              outputs
-                .push(watch_channel::convert_entry(key.entry_if_changed.as_ref())?);
-            }
-          }
-          yield outputs;
-        }
-
-        // The stream disconnected, so retry after a short delay.
-        randomized_exponential_backoff(DATAPATH_BACKOFF_BASE, attempt).await;
-      }
-    };
-    Box::pin(stream)
+    Box::pin(self.watch_stream(keys))
   }
 
   fn close(&self) {}

--- a/remote/watch_channel.rs
+++ b/remote/watch_channel.rs
@@ -1,0 +1,686 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+
+//! Multiplexed watches over a single WebSocket connection (KV Connect
+//! protocol version 4).
+//!
+//! One [`WatchChannelManager`] exists per database. All `watch()` calls
+//! subscribe through it; the manager maintains a single WebSocket channel to
+//! the server, registers each watched key once (refcounted across
+//! subscriptions), and demultiplexes key-tagged updates back to the
+//! subscriptions. When the channel is lost it reconnects with backoff and
+//! re-adds every key with the last seen versionstamp as the baseline, so
+//! reconnects deliver neither duplicates nor lose updates.
+//!
+//! When the channel cannot be made to work — the WebSocket handshake fails
+//! repeatedly (e.g. an intermediary strips the `Upgrade` header), the
+//! server keeps closing the connection, or metadata rotates to an endpoint
+//! the caller has not approved — subscriptions are failed with an error
+//! starting with [`CHANNEL_UNAVAILABLE_PREFIX`]. `Remote::watch` reacts to
+//! that marker by falling back to the protocol version 3 per-watch
+//! streaming path, which works over plain HTTP and re-checks permissions
+//! per request.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::pin::pin;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use std::time::Instant;
+
+use async_stream::try_stream;
+use deno_error::JsErrorBox;
+use denokv_proto::datapath as pb;
+use denokv_proto::decode_value;
+use denokv_proto::KvEntry;
+use denokv_proto::WatchKeyOutput;
+use futures::SinkExt;
+use futures::Stream;
+use futures::StreamExt;
+use log::debug;
+use prost::Message;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use tokio::sync::Notify;
+use tokio_util::task::AbortOnDropHandle;
+use url::Url;
+
+use crate::randomized_exponential_backoff;
+use crate::DataPathConsistency;
+use crate::MetadataState;
+use crate::RemoteTransport;
+use crate::WatchError;
+use crate::DATAPATH_BACKOFF_BASE;
+
+/// Errors with this prefix tell `Remote::watch` that the watch channel is
+/// not usable and it should fall back to per-watch streaming.
+pub(crate) const CHANNEL_UNAVAILABLE_PREFIX: &str =
+  "watch channel unavailable: ";
+
+/// A connection that stayed up at least this long is considered healthy:
+/// when it dies, the failure counter is reset so routine disconnects (idle
+/// timeouts of intermediaries, server restarts) do not accumulate, while
+/// connections that fail to establish or die quickly do.
+const HEALTHY_CONNECTION_DURATION: Duration = Duration::from_secs(30);
+
+/// After this many consecutive failed or short-lived connections the
+/// channel is declared unavailable and all subscriptions are failed (which
+/// makes their watch() calls fall back to per-watch streaming).
+const MAX_CONSECUTIVE_FAILURES: u64 = 5;
+
+type SubscriptionId = u64;
+
+/// What the client knows the server has last told it about a key.
+#[derive(Clone, PartialEq)]
+enum Baseline {
+  /// No state received yet.
+  Unknown,
+  /// The key was last seen as not present.
+  Absent,
+  /// The key was last seen with this versionstamp.
+  Versionstamp(Vec<u8>),
+}
+
+impl Baseline {
+  fn to_add_message(&self, key: &[u8]) -> pb::WatchChannelClientMessage {
+    pb::WatchChannelClientMessage {
+      message: Some(pb::watch_channel_client_message::Message::Add(
+        pb::WatchChannelAdd {
+          key: key.to_vec(),
+          baseline: match self {
+            Baseline::Unknown => None,
+            Baseline::Absent => {
+              Some(pb::watch_channel_add::Baseline::Absent(true))
+            }
+            Baseline::Versionstamp(versionstamp) => {
+              Some(pb::watch_channel_add::Baseline::Versionstamp(
+                versionstamp.clone(),
+              ))
+            }
+          },
+        },
+      )),
+    }
+  }
+}
+
+fn remove_message(key: &[u8]) -> pb::WatchChannelClientMessage {
+  pb::WatchChannelClientMessage {
+    message: Some(pb::watch_channel_client_message::Message::Remove(
+      pb::WatchChannelRemove { key: key.to_vec() },
+    )),
+  }
+}
+
+enum Command {
+  Subscribe {
+    id: SubscriptionId,
+    keys: Vec<Vec<u8>>,
+    tx: mpsc::UnboundedSender<SubscriptionEvent>,
+  },
+  Unsubscribe {
+    id: SubscriptionId,
+  },
+}
+
+enum SubscriptionEvent {
+  /// New state for some of the subscription's keys. Entries are shared
+  /// between subscriptions; they are only copied out when converted to the
+  /// caller-facing [`WatchKeyOutput`].
+  Update(Vec<(Vec<u8>, Option<Arc<pb::KvEntry>>)>),
+  /// The channel failed; the subscription stream must error out.
+  Error(String),
+}
+
+struct KeyState {
+  baseline: Baseline,
+  subscribers: HashSet<SubscriptionId>,
+}
+
+struct SubscriptionState {
+  keys: Vec<Vec<u8>>,
+  tx: mpsc::UnboundedSender<SubscriptionEvent>,
+}
+
+pub(crate) struct WatchChannelManager {
+  commands: mpsc::UnboundedSender<Command>,
+  next_subscription_id: AtomicU64,
+  /// Endpoint URLs (in their original `http`/`https` form) that have
+  /// passed the caller's permission check. The driver refuses to connect
+  /// anywhere else; see [`Driver::run_connection`].
+  approved_endpoints: Arc<Mutex<HashSet<String>>>,
+  _driver: AbortOnDropHandle<()>,
+}
+
+impl WatchChannelManager {
+  pub fn new<T: RemoteTransport>(
+    client: T,
+    metadata: watch::Receiver<MetadataState>,
+    refresh_metadata: Arc<Notify>,
+  ) -> Self {
+    let (commands_tx, commands_rx) = mpsc::unbounded_channel();
+    let approved_endpoints = Arc::new(Mutex::new(HashSet::new()));
+    let driver = Driver {
+      client,
+      metadata,
+      refresh_metadata,
+      approved_endpoints: approved_endpoints.clone(),
+      keys: HashMap::new(),
+      subscriptions: HashMap::new(),
+    };
+    let handle = tokio::spawn(driver.run(commands_rx));
+    Self {
+      commands: commands_tx,
+      next_subscription_id: AtomicU64::new(1),
+      approved_endpoints,
+      _driver: AbortOnDropHandle::new(handle),
+    }
+  }
+
+  /// Record endpoint URLs that have passed the caller's permission check.
+  pub fn approve_endpoints(&self, urls: impl IntoIterator<Item = String>) {
+    self.approved_endpoints.lock().unwrap().extend(urls);
+  }
+
+  /// Watch the given keys through the shared channel. The returned stream
+  /// has the same contract as the v3 watch stream: the first item carries
+  /// the state of every key (all `Changed`), subsequent items mark updated
+  /// keys `Changed` and all others `Unchanged`, in the order of `keys`.
+  pub fn subscribe(
+    &self,
+    keys: Vec<Vec<u8>>,
+  ) -> impl Stream<Item = Result<Vec<WatchKeyOutput>, JsErrorBox>> + Send {
+    let id = self.next_subscription_id.fetch_add(1, Ordering::Relaxed);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let _ = self.commands.send(Command::Subscribe {
+      id,
+      keys: keys.clone(),
+      tx,
+    });
+    let unsubscribe = UnsubscribeOnDrop {
+      id,
+      commands: self.commands.clone(),
+    };
+
+    // Indices per key, so duplicate keys in one watch call all get updated.
+    let mut key_indices: HashMap<Vec<u8>, Vec<usize>> = HashMap::new();
+    for (index, key) in keys.iter().enumerate() {
+      key_indices.entry(key.clone()).or_default().push(index);
+    }
+
+    try_stream! {
+      let _unsubscribe = unsubscribe;
+      // Latest known state per key position; outer None until first seen.
+      let mut latest: Vec<Option<Option<Arc<pb::KvEntry>>>> =
+        vec![None; keys.len()];
+      let mut emitted_initial = false;
+      while let Some(event) = rx.recv().await {
+        let items = match event {
+          SubscriptionEvent::Update(items) => items,
+          SubscriptionEvent::Error(error) => {
+            Err(JsErrorBox::generic(error))?;
+            unreachable!();
+          }
+        };
+        let mut touched = vec![false; keys.len()];
+        for (key, entry) in items {
+          if let Some(indices) = key_indices.get(&key) {
+            for &index in indices {
+              latest[index] = Some(entry.clone());
+              touched[index] = true;
+            }
+          }
+        }
+        if !emitted_initial {
+          // Hold the first item back until every key has reported once, so
+          // the first item is a full snapshot like in protocol version 3.
+          if latest.iter().any(|state| state.is_none()) {
+            continue;
+          }
+          emitted_initial = true;
+          let outputs = latest
+            .iter()
+            .map(|state| convert_entry(state.as_ref().unwrap().as_deref()))
+            .collect::<Result<Vec<_>, JsErrorBox>>()?;
+          yield outputs;
+        } else {
+          let outputs = (0..keys.len())
+            .map(|index| {
+              if touched[index] {
+                convert_entry(latest[index].as_ref().unwrap().as_deref())
+              } else {
+                Ok(WatchKeyOutput::Unchanged)
+              }
+            })
+            .collect::<Result<Vec<_>, JsErrorBox>>()?;
+          yield outputs;
+        }
+      }
+      // The command channel outlives all subscriptions; the event channel
+      // only closes when the manager (and thus the database) is dropped.
+    }
+  }
+}
+
+struct UnsubscribeOnDrop {
+  id: SubscriptionId,
+  commands: mpsc::UnboundedSender<Command>,
+}
+
+impl Drop for UnsubscribeOnDrop {
+  fn drop(&mut self) {
+    let _ = self.commands.send(Command::Unsubscribe { id: self.id });
+  }
+}
+
+/// Convert a protobuf entry (`None` = key not present) to the
+/// caller-facing output. Also used by the protocol version 3 watch path in
+/// `lib.rs`, so both paths decode entries identically.
+pub(crate) fn convert_entry(
+  entry: Option<&pb::KvEntry>,
+) -> Result<WatchKeyOutput, JsErrorBox> {
+  let entry = match entry {
+    Some(entry) => {
+      let value = decode_value(entry.value.clone(), entry.encoding as i64)
+        .ok_or_else(|| {
+          JsErrorBox::from_err(WatchError::UnknownEncoding(entry.encoding))
+        })?;
+      Some(KvEntry {
+        key: entry.key.clone(),
+        value,
+        versionstamp: <[u8; 10]>::try_from(&entry.versionstamp[..])
+          .map_err(|e| JsErrorBox::from_err(WatchError::TryFromSlice(e)))?,
+      })
+    }
+    None => None,
+  };
+  Ok(WatchKeyOutput::Changed { entry })
+}
+
+struct Driver<T: RemoteTransport> {
+  client: T,
+  metadata: watch::Receiver<MetadataState>,
+  refresh_metadata: Arc<Notify>,
+  approved_endpoints: Arc<Mutex<HashSet<String>>>,
+  keys: HashMap<Vec<u8>, KeyState>,
+  subscriptions: HashMap<SubscriptionId, SubscriptionState>,
+}
+
+enum ConnectionEnd {
+  /// All command senders are gone; the manager was dropped.
+  Shutdown,
+  /// The connection was lost; reconnect.
+  Reconnect,
+  /// There is nothing (left) to watch, or the failure was already
+  /// reported via fail_all; wait for new subscriptions.
+  Idle,
+}
+
+impl<T: RemoteTransport> Driver<T> {
+  async fn run(mut self, mut commands: mpsc::UnboundedReceiver<Command>) {
+    let mut consecutive_failures: u64 = 0;
+    loop {
+      // With nothing to watch there is nothing to connect for.
+      while self.keys.is_empty() {
+        match commands.recv().await {
+          Some(command) => self.handle_command_offline(command),
+          None => return,
+        }
+      }
+
+      if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
+        // The channel does not work; tell every subscription so their
+        // watch() calls fall back to per-watch streaming. New
+        // subscriptions get a fresh chance.
+        self.fail_all(format!(
+          "{CHANNEL_UNAVAILABLE_PREFIX}giving up after {consecutive_failures} consecutive failed connections"
+        ));
+        consecutive_failures = 0;
+        continue;
+      }
+
+      if consecutive_failures > 0 {
+        randomized_exponential_backoff(
+          DATAPATH_BACKOFF_BASE,
+          consecutive_failures,
+        )
+        .await;
+      }
+
+      let connected_at = Instant::now();
+      match self.run_connection(&mut commands).await {
+        ConnectionEnd::Shutdown => return,
+        ConnectionEnd::Idle => {
+          consecutive_failures = 0;
+        }
+        ConnectionEnd::Reconnect => {
+          if connected_at.elapsed() >= HEALTHY_CONNECTION_DURATION {
+            consecutive_failures = 0;
+          } else {
+            consecutive_failures += 1;
+          }
+        }
+      }
+    }
+  }
+
+  /// Register a subscription. Returns the keys that must be (re-)announced
+  /// to the server. Baselines for the subscription's keys are reset to
+  /// `Unknown` — even for keys that were already watched — so that the
+  /// state of every key is re-sent: the new subscription needs it for its
+  /// initial snapshot, and the reset (rather than only a one-shot
+  /// add-without-baseline message) guarantees the request survives a
+  /// reconnect that swallows the in-flight add.
+  fn register_subscription(
+    &mut self,
+    id: SubscriptionId,
+    keys: Vec<Vec<u8>>,
+    tx: mpsc::UnboundedSender<SubscriptionEvent>,
+  ) -> Vec<Vec<u8>> {
+    for key in &keys {
+      let state = self.keys.entry(key.clone()).or_insert(KeyState {
+        baseline: Baseline::Unknown,
+        subscribers: HashSet::new(),
+      });
+      state.subscribers.insert(id);
+      state.baseline = Baseline::Unknown;
+    }
+    let announce = keys.clone();
+    self
+      .subscriptions
+      .insert(id, SubscriptionState { keys, tx });
+    announce
+  }
+
+  /// Unregister a subscription. Returns the keys that are no longer
+  /// watched by anyone.
+  fn unregister_subscription(&mut self, id: SubscriptionId) -> Vec<Vec<u8>> {
+    let Some(subscription) = self.subscriptions.remove(&id) else {
+      return Vec::new();
+    };
+    let mut removed = Vec::new();
+    for key in subscription.keys {
+      if let Some(state) = self.keys.get_mut(&key) {
+        state.subscribers.remove(&id);
+        if state.subscribers.is_empty() {
+          self.keys.remove(&key);
+          removed.push(key);
+        }
+      }
+    }
+    removed
+  }
+
+  /// Apply a command without a live connection; adds and removes are
+  /// reconciled when the next connection is established.
+  fn handle_command_offline(&mut self, command: Command) {
+    match command {
+      Command::Subscribe { id, keys, tx } => {
+        self.register_subscription(id, keys, tx);
+      }
+      Command::Unsubscribe { id } => {
+        self.unregister_subscription(id);
+      }
+    }
+  }
+
+  /// Establish one connection and pump it until it dies, goes idle, or the
+  /// manager is dropped.
+  async fn run_connection(
+    &mut self,
+    commands: &mut mpsc::UnboundedReceiver<Command>,
+  ) -> ConnectionEnd {
+    // Wait for usable metadata.
+    let metadata = {
+      let mut metadata_rx = self.metadata.clone();
+      loop {
+        match &*metadata_rx.borrow_and_update() {
+          MetadataState::Pending => {}
+          MetadataState::Ok(metadata) => break metadata.clone(),
+          MetadataState::Error(error) => {
+            self.fail_all(format!(
+              "{CHANNEL_UNAVAILABLE_PREFIX}metadata error: {error}"
+            ));
+            return ConnectionEnd::Idle;
+          }
+        }
+        if metadata_rx.changed().await.is_err() {
+          return ConnectionEnd::Shutdown;
+        }
+      }
+    };
+
+    let Some(endpoint) = metadata
+      .endpoints
+      .iter()
+      .find(|endpoint| endpoint.consistency == DataPathConsistency::Strong)
+    else {
+      self.fail_all(format!(
+        "{CHANNEL_UNAVAILABLE_PREFIX}no strong consistency endpoints available"
+      ));
+      return ConnectionEnd::Idle;
+    };
+
+    let http_url = match Url::parse(&format!("{}/watch_channel", endpoint.url))
+    {
+      Ok(url) => url,
+      Err(error) => {
+        self.fail_all(format!(
+          "{CHANNEL_UNAVAILABLE_PREFIX}invalid endpoint URL: {error}"
+        ));
+        return ConnectionEnd::Idle;
+      }
+    };
+    // Only connect to endpoints the caller permission-checked in watch().
+    // Metadata refreshes can introduce new endpoints; those have not been
+    // checked, so the channel is declared unavailable and watch() falls
+    // back to the per-watch path, which checks permissions on every
+    // request.
+    if !self
+      .approved_endpoints
+      .lock()
+      .unwrap()
+      .contains(http_url.as_str())
+    {
+      self.fail_all(format!(
+        "{CHANNEL_UNAVAILABLE_PREFIX}endpoint '{http_url}' has not been permission-checked"
+      ));
+      return ConnectionEnd::Idle;
+    }
+    // http -> ws, https -> wss.
+    let ws_url = match Url::parse(&format!(
+      "ws{}",
+      &http_url.as_str()[4..] // strip "http"
+    )) {
+      Ok(url) => url,
+      Err(error) => {
+        self.fail_all(format!(
+          "{CHANNEL_UNAVAILABLE_PREFIX}invalid websocket URL: {error}"
+        ));
+        return ConnectionEnd::Idle;
+      }
+    };
+
+    let (mut sink, stream) = match self
+      .client
+      .websocket(ws_url.clone(), metadata.headers())
+      .await
+    {
+      Ok(connection) => connection,
+      Err(error) => {
+        debug!(
+          "KV Connect watch channel connect to '{ws_url}' failed: {error}"
+        );
+        return ConnectionEnd::Reconnect;
+      }
+    };
+    let mut stream = pin!(stream);
+
+    // Register every key, resuming from its baseline.
+    for (key, state) in &self.keys {
+      let message = state.baseline.to_add_message(key);
+      if let Err(error) = sink.send(message.encode_to_vec().into()).await {
+        debug!("KV Connect watch channel send failed: {error}");
+        return ConnectionEnd::Reconnect;
+      }
+    }
+
+    loop {
+      tokio::select! {
+        command = commands.recv() => {
+          match command {
+            Some(command) => {
+              if self.handle_command_online(command, &mut sink).await.is_err() {
+                return ConnectionEnd::Reconnect;
+              }
+              if self.keys.is_empty() {
+                // Nothing left to watch; drop the connection rather than
+                // keeping an idle socket open.
+                return ConnectionEnd::Idle;
+              }
+            }
+            None => return ConnectionEnd::Shutdown,
+          }
+        }
+        message = stream.next() => {
+          match message {
+            Some(Ok(bytes)) => {
+              match self.handle_server_message(&bytes) {
+                ServerMessageOutcome::Continue => {}
+                ServerMessageOutcome::Reconnect => return ConnectionEnd::Reconnect,
+              }
+            }
+            Some(Err(error)) => {
+              debug!("KV Connect watch channel error: {error}");
+              return ConnectionEnd::Reconnect;
+            }
+            None => {
+              debug!("KV Connect watch channel closed");
+              return ConnectionEnd::Reconnect;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /// Apply a command while connected, sending the corresponding add/remove
+  /// messages. Returns Err(()) when the connection broke.
+  async fn handle_command_online(
+    &mut self,
+    command: Command,
+    sink: &mut crate::WebSocketMessageSink,
+  ) -> Result<(), ()> {
+    match command {
+      Command::Subscribe { id, keys, tx } => {
+        for key in self.register_subscription(id, keys, tx) {
+          // The baseline was reset to Unknown, so the server re-sends the
+          // current state, which the new subscription needs for its
+          // initial snapshot. Existing subscriptions receive a redundant
+          // (but harmless) update.
+          let message = Baseline::Unknown.to_add_message(&key);
+          if let Err(error) = sink.send(message.encode_to_vec().into()).await {
+            debug!("KV Connect watch channel send failed: {error}");
+            return Err(());
+          }
+        }
+      }
+      Command::Unsubscribe { id } => {
+        for key in self.unregister_subscription(id) {
+          if let Err(error) =
+            sink.send(remove_message(&key).encode_to_vec().into()).await
+          {
+            debug!("KV Connect watch channel send failed: {error}");
+            return Err(());
+          }
+        }
+      }
+    }
+    Ok(())
+  }
+
+  fn handle_server_message(&mut self, bytes: &[u8]) -> ServerMessageOutcome {
+    let message = match pb::WatchChannelServerMessage::decode(bytes) {
+      Ok(message) => message,
+      Err(error) => {
+        // A malformed frame is a server bug, but baselines are intact, so
+        // a reconnect is lossless. If the server keeps sending garbage the
+        // connections die young and the failure counter eventually
+        // declares the channel unavailable.
+        debug!("KV Connect watch channel sent an invalid message: {error}");
+        return ServerMessageOutcome::Reconnect;
+      }
+    };
+    let Some(pb::watch_channel_server_message::Message::Output(output)) =
+      message.message
+    else {
+      // Unknown message type from a newer server; ignore.
+      return ServerMessageOutcome::Continue;
+    };
+
+    match output.status() {
+      pb::SnapshotReadStatus::SrSuccess => {}
+      pb::SnapshotReadStatus::SrReadDisabled => {
+        // Endpoints changed; get fresh metadata and reconnect.
+        self.refresh_metadata.notify_one();
+        return ServerMessageOutcome::Reconnect;
+      }
+      pb::SnapshotReadStatus::SrUnspecified => {
+        self.fail_all(format!(
+          "KV Connect watch channel read error (code={})",
+          output.status
+        ));
+        return ServerMessageOutcome::Reconnect;
+      }
+    }
+
+    // Update baselines and fan updates out per subscription. Entries are
+    // wrapped in Arc once so fan-out does not copy values.
+    type Updates = Vec<(Vec<u8>, Option<Arc<pb::KvEntry>>)>;
+    let mut per_subscription: HashMap<SubscriptionId, Updates> = HashMap::new();
+    for key_output in output.keys {
+      let Some(state) = self.keys.get_mut(&key_output.key) else {
+        // Update for a key we no longer watch (remove still in flight).
+        continue;
+      };
+      state.baseline = match &key_output.entry {
+        Some(entry) => Baseline::Versionstamp(entry.versionstamp.clone()),
+        None => Baseline::Absent,
+      };
+      let entry = key_output.entry.map(Arc::new);
+      for id in &state.subscribers {
+        per_subscription
+          .entry(*id)
+          .or_default()
+          .push((key_output.key.clone(), entry.clone()));
+      }
+    }
+    for (id, items) in per_subscription {
+      if let Some(subscription) = self.subscriptions.get(&id) {
+        // A send failure means the subscription stream was dropped; its
+        // Unsubscribe command is already queued and will clean up.
+        let _ = subscription.tx.send(SubscriptionEvent::Update(items));
+      }
+    }
+    ServerMessageOutcome::Continue
+  }
+
+  /// Report an error to all subscriptions and drop all state. New
+  /// subscriptions start with a clean slate.
+  fn fail_all(&mut self, error: String) {
+    for subscription in self.subscriptions.values() {
+      let _ = subscription
+        .tx
+        .send(SubscriptionEvent::Error(error.clone()));
+    }
+    self.subscriptions.clear();
+    self.keys.clear();
+  }
+}
+
+enum ServerMessageOutcome {
+  Continue,
+  Reconnect,
+}

--- a/remote/watch_channel.rs
+++ b/remote/watch_channel.rs
@@ -313,6 +313,10 @@ enum ConnectionEnd {
   Shutdown,
   /// The connection was lost; reconnect.
   Reconnect,
+  /// The server violated the protocol; reconnect, but always count it as a
+  /// failure so a repeating poison frame cannot loop without backoff (the
+  /// connection may have been long-lived before the bad frame arrived).
+  ProtocolError,
   /// There is nothing (left) to watch, or the failure was already
   /// reported via fail_all; wait for new subscriptions.
   Idle,
@@ -361,6 +365,9 @@ impl<T: RemoteTransport> Driver<T> {
           } else {
             consecutive_failures += 1;
           }
+        }
+        ConnectionEnd::ProtocolError => {
+          consecutive_failures += 1;
         }
       }
     }
@@ -550,6 +557,9 @@ impl<T: RemoteTransport> Driver<T> {
               match self.handle_server_message(&bytes) {
                 ServerMessageOutcome::Continue => {}
                 ServerMessageOutcome::Reconnect => return ConnectionEnd::Reconnect,
+                ServerMessageOutcome::ProtocolError => {
+                  return ConnectionEnd::ProtocolError
+                }
               }
             }
             Some(Err(error)) => {
@@ -606,11 +616,11 @@ impl<T: RemoteTransport> Driver<T> {
       Ok(message) => message,
       Err(error) => {
         // A malformed frame is a server bug, but baselines are intact, so
-        // a reconnect is lossless. If the server keeps sending garbage the
-        // connections die young and the failure counter eventually
-        // declares the channel unavailable.
+        // a reconnect is lossless. Counted as a failure regardless of
+        // connection age so persistent garbage eventually declares the
+        // channel unavailable.
         debug!("KV Connect watch channel sent an invalid message: {error}");
-        return ServerMessageOutcome::Reconnect;
+        return ServerMessageOutcome::ProtocolError;
       }
     };
     let Some(pb::watch_channel_server_message::Message::Output(output)) =
@@ -683,4 +693,5 @@ impl<T: RemoteTransport> Driver<T> {
 enum ServerMessageOutcome {
   Continue,
   Reconnect,
+  ProtocolError,
 }


### PR DESCRIPTION
Adds KV Connect protocol version 4: a multiplexed watch channel.

Today every `watch()` call opens its own long-lived streaming request,
so a client watching many key sets holds many concurrent streams, and
every reconnect re-delivers state the client already has. Version 4
multiplexes all watches for a database over one WebSocket connection:

* Keys are added/removed in-band (`WatchChannelClientMessage`), so the
  watched set changes without new connections. The `add` message
  carries an optional baseline (last seen versionstamp, or "absent");
  the server only sends state that differs from it. Re-adding all keys
  with their baselines after a reconnect makes resumption lossless and
  duplicate-free.
* Server messages are key-tagged and sparse (only changed keys),
  unlike the positional v3 `WatchOutput`.
* `RemoteTransport` gains optional WebSocket support via defaulted
  methods, so this is semver-compatible: existing transports keep
  compiling, keep advertising `[1, 2, 3]`, and keep the per-watch v3
  path. Only transports that implement `websocket()` negotiate v4.
  Nothing changes for any current consumer until its transport opts
  in.
* The `denokv` server gains the `/watch_channel` endpoint (axum ws)
  behind the same auth, diffs updates against per-client known state,
  enforces a per-channel key cap (1024, close code 1008), and pings
  every 5s. Metadata negotiation now prefers v4.
* The `watch()` stream contract is identical under both protocols:
  first item is a full snapshot, later items mark untouched keys
  `Unchanged`, in request key order — covered by integration tests
  that exercise the channel path (shared channel across watches,
  initial snapshots, per-key updates, re-subscription) next to the
  existing v3 test.

Spec for the new endpoint and messages is in `proto/kv-connect.md`
("Watch Channel (version 4)").
